### PR TITLE
Add more travis tests and update coarseDataTools remote

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,3 +2,4 @@ fitRotavirus.R
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^\.travis.yml
+^\.travis\.yml$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,5 +1,5 @@
 fitRotavirus.R
 ^.*\.Rproj$
 ^\.Rproj\.user$
-^\.travis.yml
 ^\.travis\.yml$
+^codecov\.yml$

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,35 @@
 language: r
 cache: packages
+
+matrix:
+  include:
+    - os: linux
+      r: release
+      env:
+        - R_CODECOV=true
+    - os: linux
+      r: devel
+    - os: linux
+      r: oldrel
+    - os: osx
+      osx_image: xcode8.3
+
+warnings_are_errors: true
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change
+
+after_success:
+  - if [[ "${R_CODECOV}" ]]; then Rscript -e 'covr::codecov()'; fi
+
+env:
+  global:
+    - NOT_CRAN: true
+    - R_BUILD_ARGS="--resave-data --compact-vignettes=gs+qpdf"
+    - R_CHECK_ARGS="--as-cran --timings"
+    - R_CHECK_TIME="TRUE"
+    - R_CHECK_TESTS="TRUE"
+    - _R_CHECK_TIMINGS_="0"
+    - _R_CHECK_SYSTEM_CLOCK_="0"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: EpiEstim
-Version: 2.0-0
+Version: 2.1-0
 Title: EpiEstim: a package to estimate time varying reproduction
     numbers from epidemic curves
 Author: Anne Cori <a.cori@imperial.ac.uk>
@@ -27,7 +27,8 @@ Remotes:
 Suggests:
     testthat,
     compare,
-    utils
+    utils,
+    covr
 License: GPL (>=2)
 LazyLoad: yes
 Packaged: 2012-05-30 10:35:03 UTC; acori

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,5 @@
 Package: EpiEstim
-Version: 2.1-0
-Date: 2012/01/17
+Version: 2.0-0
 Title: EpiEstim: a package to estimate time varying reproduction
     numbers from epidemic curves
 Author: Anne Cori <a.cori@imperial.ac.uk>
@@ -22,11 +21,9 @@ Imports:
     coda,
     incidence,
     scales,
-    grDevices,
-    knitr
+    grDevices
 Remotes:
-    reconhub/incidence,
-    nickreich/coarseDataTools@hackout3
+    nickreich/coarseDataTools
 Suggests:
     testthat,
     compare,
@@ -34,5 +31,4 @@ Suggests:
 License: GPL (>=2)
 LazyLoad: yes
 Packaged: 2012-05-30 10:35:03 UTC; acori
-VignetteBuilder: knitr
-RoxygenNote: 6.1.1
+RoxygenNote: 6.0.1.9000

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 <!-- badges: start -->
 [![Travis build status](https://travis-ci.org/annecori/EpiEstim.svg?branch=master)](https://travis-ci.org/annecori/EpiEstim)
+[![Codecov test coverage](https://codecov.io/gh/annecori/EpiEstim/branch/master/graph/badge.svg)](https://codecov.io/gh/annecori/EpiEstim?branch=master)
 <!-- badges: end -->
 
 A tool to estimate time varying instantaneous reproduction number during epidemics

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # EpiEstim
+
+<!-- badges: start -->
+[![Travis build status](https://travis-ci.org/annecori/EpiEstim.svg?branch=master)](https://travis-ci.org/annecori/EpiEstim)
+<!-- badges: end -->
+
 A tool to estimate time varying instantaneous reproduction number during epidemics
 
 This tool is described in the following paper: 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%


### PR DESCRIPTION
I just got a positive confirmation from the developer of coarseDataTools that he will merge the package into master and submit it to cran, so I am removing the hackout3 branch here.

I'm also getting travis to run on different architectures and report coverage (when set up)