### PR TITLE
Wallinga fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ matrix:
     - os: linux
       r: devel
     - os: osx
-      osx_image: xcode8.3
+      osx_image: xcode9.4
+
+before_install: if [ "$TRAVIS_OS_NAME" = "osx" ]; then sudo tlmgr install inconsolata; fi
+
 
 warnings_are_errors: true
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ## FIXED
+* Fixed bugs in draw_one_set_of_ancestries resulting from incorrect lengths and an undefined variable (issue #92) (#93, @jstockwin)
 * Fixed incorrect quantiles (issue #88) (#89, @jstockwin)
 
 # EpiEstim 2.2-2

--- a/R/wallinga_teunis.R
+++ b/R/wallinga_teunis.R
@@ -121,7 +121,7 @@ wallinga_teunis <- function(incid,
   
   draw_one_set_of_ancestries <- function() {
     res <- vector()
-    for (t in seq(config$t_start[1], config$t_end[length(config$t_end)]))
+    for (t in seq_len(T))
     {
       if (length(which(Onset == t)) > 0) {
         if (length(possible_ances_time[[t]]) > 0) {

--- a/R/wallinga_teunis.R
+++ b/R/wallinga_teunis.R
@@ -127,8 +127,8 @@ wallinga_teunis <- function(incid,
         if (length(possible_ances_time[[t]]) > 0) {
           prob <- config$si_distr[t - possible_ances_time[[t]] + 1] *
             incid[possible_ances_time[[t]]]
+          ot <- which(Onset == t)
           if (any(prob > 0)) {
-            ot <- which(Onset == t)
             res[ot] <-
               possible_ances_time[[t]][which(rmultinom(length(ot),
                                                        size = 1, prob = prob)


### PR DESCRIPTION
**Pull Request**
Closes #92 

- Fixes a bug where `draw_one_set_of_ancestries` would return a result of the wrong length. It would calculate the length based on the time window, but everything else is based on `T`. I am not familiar with the actual maths involved here, so please do check this is correct.

- Fixes a bug where `ot` was not defined.

**How has this been tested**
Examples were given in #92, and these now work correctly.

**Checklist**
- [X] I have added tests to prove my changes work
- [X] I have added documentation where required
- [X] I have updated `NEWS.md` with a short description of my change
