### PR TITLE
Ignore more files

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,4 @@ fitRotavirus.R
 ^codecov\.yml$
 ^CRAN-RELEASE$
 ^cran-comments\.md$
+^\.github$


### PR DESCRIPTION
This PR adds `.github` to the `.Rbuildignore`, which silences a CRAN NOTE.

**How has this been tested**

I've tested this locally and travis should run it.

**Checklist**
- [ ] I have added tests to prove my changes work (NA)
- [ ] I have added documentation where required (NA)
- [ ] I have updated `NEWS.md` with a short description of my change (NA)
