### PR TITLE
Fix vdiffr tests broken (fixes #106)

### DIFF
--- a/R/test_utils.R
+++ b/R/test_utils.R
@@ -1,0 +1,37 @@
+#' Expect doppelgangers skipped on CI if missing snapshot
+#' 
+#' See `tests/testthat/test-plots.R`.
+#'
+#' @param name Character. Snapshot name.
+#' @param code Code to create image to snapshot.
+#' @param variant Character. Variant for the snapshot
+#' 
+#' @returns snapshot or skip
+#' 
+#' @noRd
+
+epi_expect_doppelganger <- function(name, code, variant) {
+
+  testthat::skip_if_not_installed("vdiffr")
+
+  on_ci <- as.logical(Sys.getenv("CI", "false"))
+  no_snap <- !file.exists(
+    testthat::test_path(
+      "_snaps",
+      variant,
+      paste0(name, ".svg")
+    )
+  )
+  if (on_ci && no_snap) {
+    testthat::skip(
+      paste0("On CI and no snapshot for this variant (", variant, ")")
+    )
+  }
+
+  vdiffr::expect_doppelganger(
+    name,
+    code,
+    variant = variant
+  )
+}
+

--- a/tests/testthat/_snaps/Darwin/plot/flu2009-incidence-import.svg
+++ b/tests/testthat/_snaps/Darwin/plot/flu2009-incidence-import.svg
@@ -1,0 +1,145 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNTIuMjh8NzE0LjUyfDMxLjE3fDUzMi4xOA=='>
+    <rect x='52.28' y='31.17' width='662.24' height='501.01' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTIuMjh8NzE0LjUyfDMxLjE3fDUzMi4xOA==)'>
+<rect x='52.28' y='31.17' width='662.24' height='501.01' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='52.28,484.01 714.52,484.01 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,387.66 714.52,387.66 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,291.31 714.52,291.31 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,194.96 714.52,194.96 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,98.62 714.52,98.62 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='148.23,532.18 148.23,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='279.92,532.18 279.92,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='411.62,532.18 411.62,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='543.32,532.18 543.32,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='675.01,532.18 675.01,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,532.18 714.52,532.18 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,435.83 714.52,435.83 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,339.49 714.52,339.49 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,243.14 714.52,243.14 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,146.79 714.52,146.79 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,50.44 714.52,50.44 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='82.38,532.18 82.38,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='214.08,532.18 214.08,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='345.77,532.18 345.77,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='477.47,532.18 477.47,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='609.16,532.18 609.16,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<rect x='82.38' y='493.64' width='18.81' height='38.54' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='101.19' y='493.64' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='120.01' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='138.82' y='455.10' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='157.63' y='339.49' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='176.45' y='416.56' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='195.26' y='416.56' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='214.08' y='416.56' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='232.89' y='300.95' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='251.70' y='455.10' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='270.52' y='339.49' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='289.33' y='185.33' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='308.14' y='31.17' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='326.96' y='69.71' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='345.77' y='31.17' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='364.59' y='108.25' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='383.40' y='69.71' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='402.21' y='300.95' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='421.03' y='300.95' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='439.84' y='300.95' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='458.65' y='416.56' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='477.47' y='493.64' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='496.28' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='515.10' y='455.10' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='533.91' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='552.72' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='571.54' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='590.35' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='609.16' y='455.10' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='627.98' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='646.79' y='455.10' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='665.60' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='82.38' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='101.19' y='493.64' width='18.81' height='38.54' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='120.01' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='138.82' y='455.10' width='18.81' height='77.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='157.63' y='339.49' width='18.81' height='192.70' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='176.45' y='416.56' width='18.81' height='115.62' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='195.26' y='416.56' width='18.81' height='115.62' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='214.08' y='416.56' width='18.81' height='115.62' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='232.89' y='300.95' width='18.81' height='231.23' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='251.70' y='455.10' width='18.81' height='77.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='270.52' y='339.49' width='18.81' height='192.70' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='289.33' y='185.33' width='18.81' height='346.85' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='308.14' y='31.17' width='18.81' height='501.01' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='326.96' y='69.71' width='18.81' height='462.47' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='345.77' y='31.17' width='18.81' height='501.01' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='364.59' y='108.25' width='18.81' height='423.93' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='383.40' y='69.71' width='18.81' height='462.47' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='402.21' y='300.95' width='18.81' height='231.23' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='421.03' y='300.95' width='18.81' height='231.23' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='439.84' y='300.95' width='18.81' height='231.23' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='458.65' y='416.56' width='18.81' height='115.62' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='477.47' y='493.64' width='18.81' height='38.54' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='496.28' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='515.10' y='455.10' width='18.81' height='77.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='533.91' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='552.72' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='571.54' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='590.35' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='609.16' y='455.10' width='18.81' height='77.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='627.98' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='646.79' y='455.10' width='18.81' height='77.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='665.60' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='52.28,532.18 52.28,31.17 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<text x='36.79' y='535.28' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='36.79' y='438.93' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='36.79' y='342.58' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<text x='36.79' y='246.23' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>7.5</text>
+<text x='36.79' y='149.89' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='17.52px' lengthAdjust='spacingAndGlyphs'>10.0</text>
+<text x='36.79' y='53.54' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='17.52px' lengthAdjust='spacingAndGlyphs'>12.5</text>
+<polyline points='49.54,532.18 52.28,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='49.54,435.83 52.28,435.83 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='49.54,339.49 52.28,339.49 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='49.54,243.14 52.28,243.14 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='49.54,146.79 52.28,146.79 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='49.54,50.44 52.28,50.44 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='52.28,532.18 714.52,532.18 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<polyline points='82.38,534.92 82.38,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='214.08,534.92 214.08,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='345.77,534.92 345.77,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='477.47,534.92 477.47,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='609.16,534.92 609.16,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<text x='82.38' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-04-27</text>
+<text x='214.08' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-04</text>
+<text x='345.77' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-11</text>
+<text x='477.47' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-18</text>
+<text x='609.16' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-25</text>
+<text x='383.40' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
+<text transform='translate(13.05,281.68) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='47.10px' lengthAdjust='spacingAndGlyphs'>Incidence</text>
+<text x='52.28' y='16.23' style='font-size: 12.00px; font-family: sans;' textLength='82.05px' lengthAdjust='spacingAndGlyphs'>Epidemic curve</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/Darwin/plot/flu2009-instantaneous-no-legend.svg
+++ b/tests/testthat/_snaps/Darwin/plot/flu2009-instantaneous-no-legend.svg
@@ -1,0 +1,253 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNTcuNzZ8NzA5LjA0fDUzLjk2fDUyNi43MA=='>
+    <rect x='57.76' y='53.96' width='651.28' height='472.75' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTcuNzZ8NzA5LjA0fDUzLjk2fDUyNi43MA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8MjIuNzh8MjA1LjM2'>
+    <rect x='5.48' y='22.78' width='709.04' height='182.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8MjIuNzh8MjA1LjM2)'>
+<rect x='5.48' y='22.78' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA=='>
+    <rect x='5.48' y='205.36' width='709.04' height='182.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA==)'>
+<rect x='5.48' y='205.36' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg=='>
+    <rect x='5.48' y='387.94' width='709.04' height='182.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg==)'>
+<rect x='5.48' y='387.94' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTcuNzZ8NzA5LjA0fDUzLjk2fDE2MS41NA=='>
+    <rect x='57.76' y='53.96' width='651.28' height='107.59' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTcuNzZ8NzA5LjA0fDUzLjk2fDE2MS41NA==)'>
+<rect x='57.76' y='53.96' width='651.28' height='107.59' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='57.76,151.20 709.04,151.20 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,130.51 709.04,130.51 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,109.82 709.04,109.82 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,89.13 709.04,89.13 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,68.44 709.04,68.44 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='152.12,161.54 152.12,53.96 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='281.64,161.54 281.64,53.96 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='411.15,161.54 411.15,53.96 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='540.67,161.54 540.67,53.96 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='670.19,161.54 670.19,53.96 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,161.54 709.04,161.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,140.85 709.04,140.85 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,120.16 709.04,120.16 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,99.47 709.04,99.47 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,78.78 709.04,78.78 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,58.09 709.04,58.09 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='87.36,161.54 87.36,53.96 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='216.88,161.54 216.88,53.96 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='346.39,161.54 346.39,53.96 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='475.91,161.54 475.91,53.96 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='605.43,161.54 605.43,53.96 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<rect x='87.36' y='153.27' width='18.50' height='8.28' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='105.86' y='153.27' width='18.50' height='8.28' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='124.37' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='142.87' y='144.99' width='18.50' height='16.55' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='161.37' y='120.16' width='18.50' height='41.38' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='179.87' y='136.72' width='18.50' height='24.83' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='198.38' y='136.72' width='18.50' height='24.83' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='216.88' y='136.72' width='18.50' height='24.83' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='235.38' y='111.89' width='18.50' height='49.66' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='253.88' y='144.99' width='18.50' height='16.55' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='272.39' y='120.16' width='18.50' height='41.38' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='290.89' y='87.06' width='18.50' height='74.48' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='309.39' y='53.96' width='18.50' height='107.59' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='327.89' y='62.23' width='18.50' height='99.31' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='346.39' y='53.96' width='18.50' height='107.59' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='364.90' y='70.51' width='18.50' height='91.04' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='383.40' y='62.23' width='18.50' height='99.31' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='401.90' y='111.89' width='18.50' height='49.66' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='420.40' y='111.89' width='18.50' height='49.66' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='438.91' y='111.89' width='18.50' height='49.66' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='457.41' y='136.72' width='18.50' height='24.83' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='475.91' y='153.27' width='18.50' height='8.28' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='494.41' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='512.92' y='144.99' width='18.50' height='16.55' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='531.42' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='549.92' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='568.42' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='586.93' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='605.43' y='144.99' width='18.50' height='16.55' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='623.93' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='642.43' y='144.99' width='18.50' height='16.55' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='660.93' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='57.76,161.54 57.76,53.96 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<text x='42.27' y='164.64' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='42.27' y='143.95' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='42.27' y='123.26' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<text x='42.27' y='102.57' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>7.5</text>
+<text x='42.27' y='81.88' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='17.52px' lengthAdjust='spacingAndGlyphs'>10.0</text>
+<text x='42.27' y='61.19' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='17.52px' lengthAdjust='spacingAndGlyphs'>12.5</text>
+<polyline points='55.02,161.54 57.76,161.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,140.85 57.76,140.85 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,120.16 57.76,120.16 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,99.47 57.76,99.47 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,78.78 57.76,78.78 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,58.09 57.76,58.09 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='57.76,161.54 709.04,161.54 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<polyline points='87.36,164.28 87.36,161.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='216.88,164.28 216.88,161.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='346.39,164.28 346.39,161.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='475.91,164.28 475.91,161.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='605.43,164.28 605.43,161.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<text x='87.36' y='176.39' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-04-27</text>
+<text x='216.88' y='176.39' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-04</text>
+<text x='346.39' y='176.39' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-11</text>
+<text x='475.91' y='176.39' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-18</text>
+<text x='605.43' y='176.39' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-25</text>
+<text x='383.40' y='197.60' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
+<text transform='translate(18.53,107.75) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='47.10px' lengthAdjust='spacingAndGlyphs'>Incidence</text>
+<text x='57.76' y='39.01' style='font-size: 12.00px; font-family: sans;' textLength='82.05px' lengthAdjust='spacingAndGlyphs'>Epidemic curve</text>
+</g>
+<defs>
+  <clipPath id='cpNTcuNzZ8NzA5LjA0fDIzNi41NHwzNDQuMTI='>
+    <rect x='57.76' y='236.54' width='651.28' height='107.59' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTcuNzZ8NzA5LjA0fDIzNi41NHwzNDQuMTI=)'>
+<rect x='57.76' y='236.54' width='651.28' height='107.59' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='57.76,320.60 709.04,320.60 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,283.33 709.04,283.33 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,246.07 709.04,246.07 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='152.12,344.12 152.12,236.54 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='281.64,344.12 281.64,236.54 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='411.15,344.12 411.15,236.54 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='540.67,344.12 540.67,236.54 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='670.19,344.12 670.19,236.54 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,339.23 709.04,339.23 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,301.97 709.04,301.97 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,264.70 709.04,264.70 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='87.36,344.12 87.36,236.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='216.88,344.12 216.88,236.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='346.39,344.12 346.39,236.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='475.91,344.12 475.91,236.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='605.43,344.12 605.43,236.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polygon points='216.88,241.43 235.38,244.84 253.88,257.41 272.39,264.38 290.89,266.35 309.39,258.54 327.89,259.10 346.39,263.00 364.90,272.15 383.40,274.31 401.90,281.79 420.40,289.22 438.91,295.47 457.41,300.35 475.91,305.53 494.41,309.41 512.92,312.67 531.42,312.86 549.92,314.15 568.42,318.53 586.93,319.63 605.43,304.29 623.93,287.67 642.43,273.32 660.93,262.59 660.93,327.08 642.43,328.78 623.93,331.06 605.43,333.69 586.93,336.80 568.42,334.77 549.92,330.95 531.42,328.63 512.92,327.20 494.41,323.93 475.91,320.38 457.41,316.04 438.91,312.17 420.40,307.57 401.90,302.54 383.40,297.88 364.90,297.90 346.39,293.18 327.89,293.07 309.39,295.32 290.89,302.98 272.39,303.78 253.88,302.16 235.38,297.91 216.88,300.90 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #5983AB; fill-opacity: 0.20;' />
+<polyline points='216.88,241.43 235.38,244.84 253.88,257.41 272.39,264.38 290.89,266.35 309.39,258.54 327.89,259.10 346.39,263.00 364.90,272.15 383.40,274.31 401.90,281.79 420.40,289.22 438.91,295.47 457.41,300.35 475.91,305.53 494.41,309.41 512.92,312.67 531.42,312.86 549.92,314.15 568.42,318.53 586.93,319.63 605.43,304.29 623.93,287.67 642.43,273.32 660.93,262.59 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='660.93,327.08 642.43,328.78 623.93,331.06 605.43,333.69 586.93,336.80 568.42,334.77 549.92,330.95 531.42,328.63 512.92,327.20 494.41,323.93 475.91,320.38 457.41,316.04 438.91,312.17 420.40,307.57 401.90,302.54 383.40,297.88 364.90,297.90 346.39,293.18 327.89,293.07 309.39,295.32 290.89,302.98 272.39,303.78 253.88,302.16 235.38,297.91 216.88,300.90 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='216.88,274.55 235.38,274.05 253.88,281.95 272.39,285.88 290.89,286.23 309.39,278.30 327.89,277.23 346.39,279.02 364.90,285.79 383.40,286.75 401.90,292.73 420.40,298.91 438.91,304.32 457.41,308.69 475.91,313.49 494.41,317.27 512.92,320.64 531.42,321.62 549.92,323.68 568.42,328.14 586.93,330.29 605.43,322.17 623.93,314.06 642.43,307.06 660.93,301.82 ' style='stroke-width: 1.07; stroke: #5983AB; stroke-linecap: butt;' />
+<line x1='57.76' y1='301.97' x2='709.04' y2='301.97' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='57.76,344.12 57.76,236.54 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<text x='42.27' y='342.33' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='42.27' y='305.06' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='42.27' y='267.80' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>2</text>
+<polyline points='55.02,339.23 57.76,339.23 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,301.97 57.76,301.97 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,264.70 57.76,264.70 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='57.76,344.12 709.04,344.12 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<polyline points='87.36,346.86 87.36,344.12 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='216.88,346.86 216.88,344.12 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='346.39,346.86 346.39,344.12 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='475.91,346.86 475.91,344.12 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='605.43,346.86 605.43,344.12 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<text x='87.36' y='358.97' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='26.52px' lengthAdjust='spacingAndGlyphs'>Apr 27</text>
+<text x='216.88' y='358.97' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 04</text>
+<text x='346.39' y='358.97' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 11</text>
+<text x='475.91' y='358.97' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 18</text>
+<text x='605.43' y='358.97' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 25</text>
+<text x='383.40' y='380.18' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
+<text transform='translate(18.53,290.33) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='7.95px' lengthAdjust='spacingAndGlyphs'>R</text>
+<text x='57.76' y='221.59' style='font-size: 12.00px; font-family: sans;' textLength='65.37px' lengthAdjust='spacingAndGlyphs'>Estimated R</text>
+</g>
+<defs>
+  <clipPath id='cpNTcuNzZ8NzA5LjA0fDQxOS4xMXw1MjYuNzA='>
+    <rect x='57.76' y='419.11' width='651.28' height='107.59' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTcuNzZ8NzA5LjA0fDQxOS4xMXw1MjYuNzA=)'>
+<rect x='57.76' y='419.11' width='651.28' height='107.59' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='57.76,511.72 709.04,511.72 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,481.75 709.04,481.75 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,451.78 709.04,451.78 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,421.81 709.04,421.81 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='168.10,526.70 168.10,419.11 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='329.57,526.70 329.57,419.11 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='491.05,526.70 491.05,419.11 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='652.52,526.70 652.52,419.11 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,526.70 709.04,526.70 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,496.73 709.04,496.73 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,466.76 709.04,466.76 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,436.80 709.04,436.80 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='87.36,526.70 87.36,419.11 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='248.84,526.70 248.84,419.11 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='410.31,526.70 410.31,419.11 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='571.79,526.70 571.79,419.11 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='87.36,526.70 141.19,456.87 195.01,419.11 248.84,467.36 302.66,495.83 356.49,510.82 410.31,518.61 464.14,522.51 517.96,524.60 571.79,525.80 625.61,526.10 679.44,526.40 ' style='stroke-width: 1.07; stroke: #000000; stroke-opacity: 0.25; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='57.76,526.70 57.76,419.11 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<text x='42.27' y='529.80' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='42.27' y='499.83' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='42.27' y='469.86' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='42.27' y='439.89' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<polyline points='55.02,526.70 57.76,526.70 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,496.73 57.76,496.73 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,466.76 57.76,466.76 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,436.80 57.76,436.80 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='57.76,526.70 709.04,526.70 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<polyline points='87.36,529.44 87.36,526.70 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='248.84,529.44 248.84,526.70 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='410.31,529.44 410.31,526.70 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='571.79,529.44 571.79,526.70 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<text x='87.36' y='541.55' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='248.84' y='541.55' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='410.31' y='541.55' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='571.79' y='541.55' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>9</text>
+<text x='383.40' y='562.76' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
+<text transform='translate(18.53,472.91) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='51.98px' lengthAdjust='spacingAndGlyphs'>Frequency</text>
+<text x='57.76' y='404.17' style='font-size: 12.00px; font-family: sans;' textLength='123.41px' lengthAdjust='spacingAndGlyphs'>Explored SI distribution</text>
+<text x='10.96' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='197.42px' lengthAdjust='spacingAndGlyphs'>Flu2009-instantaneous-no-legend</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/Darwin/plot/flu2009-rc.svg
+++ b/tests/testthat/_snaps/Darwin/plot/flu2009-rc.svg
@@ -1,0 +1,88 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzkuNzd8NjUxLjQ2fDMxLjE3fDUzMi4xOA=='>
+    <rect x='39.77' y='31.17' width='611.69' height='501.01' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzkuNzd8NjUxLjQ2fDMxLjE3fDUzMi4xOA==)'>
+<rect x='39.77' y='31.17' width='611.69' height='501.01' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='39.77,452.48 651.46,452.48 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,338.61 651.46,338.61 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,224.74 651.46,224.74 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,110.88 651.46,110.88 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='128.39,532.18 128.39,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='250.03,532.18 250.03,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='371.68,532.18 371.68,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='493.32,532.18 493.32,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='614.96,532.18 614.96,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,509.41 651.46,509.41 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,395.54 651.46,395.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,281.68 651.46,281.68 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,167.81 651.46,167.81 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,53.95 651.46,53.95 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='67.57,532.18 67.57,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='189.21,532.18 189.21,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='310.86,532.18 310.86,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='432.50,532.18 432.50,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='554.14,532.18 554.14,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polygon points='189.21,301.77 206.59,317.91 223.97,315.96 241.35,329.02 258.72,308.22 276.10,326.74 293.48,347.72 310.86,360.34 328.23,371.63 345.61,386.62 362.99,398.39 380.37,415.82 397.74,427.76 415.12,437.94 432.50,448.68 449.88,449.88 467.25,449.87 484.63,458.80 502.01,461.96 519.39,452.48 536.76,404.08 554.14,395.54 571.52,395.54 588.90,452.48 606.27,452.48 606.27,452.48 588.90,452.48 571.52,424.01 554.14,424.01 536.76,471.45 519.39,471.45 502.01,480.94 484.63,482.68 467.25,475.13 449.88,471.82 432.50,469.18 415.12,451.48 397.74,441.74 380.37,427.95 362.99,410.52 345.61,404.80 328.23,392.61 310.86,381.40 293.48,365.43 276.10,351.11 258.72,336.77 241.35,366.44 223.97,362.81 206.59,363.84 189.21,340.45 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #5983AB; fill-opacity: 0.20;' />
+<polyline points='189.21,301.77 206.59,317.91 223.97,315.96 241.35,329.02 258.72,308.22 276.10,326.74 293.48,347.72 310.86,360.34 328.23,371.63 345.61,386.62 362.99,398.39 380.37,415.82 397.74,427.76 415.12,437.94 432.50,448.68 449.88,449.88 467.25,449.87 484.63,458.80 502.01,461.96 519.39,452.48 536.76,404.08 554.14,395.54 571.52,395.54 588.90,452.48 606.27,452.48 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='606.27,452.48 588.90,452.48 571.52,424.01 554.14,424.01 536.76,471.45 519.39,471.45 502.01,480.94 484.63,482.68 467.25,475.13 449.88,471.82 432.50,469.18 415.12,451.48 397.74,441.74 380.37,427.95 362.99,410.52 345.61,404.80 328.23,392.61 310.86,381.40 293.48,365.43 276.10,351.11 258.72,336.77 241.35,366.44 223.97,362.81 206.59,363.84 189.21,340.45 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='189.21,334.66 206.59,343.57 223.97,339.00 241.35,337.33 258.72,330.56 276.10,342.17 293.48,355.58 310.86,368.94 328.23,382.71 345.61,395.76 362.99,407.39 380.37,421.19 397.74,435.17 415.12,444.85 432.50,453.20 449.88,458.85 467.25,462.14 484.63,466.37 502.01,468.63 519.39,459.84 536.76,443.36 554.14,419.50 571.52,419.50 588.90,455.69 606.27,455.69 ' style='stroke-width: 1.07; stroke: #5983AB; stroke-linecap: butt;' />
+<line x1='39.77' y1='395.54' x2='651.46' y2='395.54' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='39.77,532.18 39.77,31.17 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<text x='30.54' y='512.50' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='30.54' y='398.64' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='30.54' y='284.77' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='30.54' y='170.91' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='30.54' y='57.04' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>4</text>
+<polyline points='37.03,509.41 39.77,509.41 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,395.54 39.77,395.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,281.68 39.77,281.68 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,167.81 39.77,167.81 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,53.95 39.77,53.95 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='39.77,532.18 651.46,532.18 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<polyline points='67.57,534.92 67.57,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='189.21,534.92 189.21,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='310.86,534.92 310.86,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='432.50,534.92 432.50,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='554.14,534.92 554.14,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<text x='67.57' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='26.52px' lengthAdjust='spacingAndGlyphs'>Apr 27</text>
+<text x='189.21' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 04</text>
+<text x='310.86' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 11</text>
+<text x='432.50' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 18</text>
+<text x='554.14' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 25</text>
+<text x='345.61' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
+<text transform='translate(13.05,281.68) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='7.95px' lengthAdjust='spacingAndGlyphs'>R</text>
+<rect x='662.41' y='258.92' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none;' />
+<line x1='664.14' y1='267.56' x2='677.97' y2='267.56' style='stroke-width: 1.07; stroke: #5983AB; stroke-linecap: butt;' />
+<text x='685.17' y='270.59' style='font-size: 8.80px; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>Mean</text>
+<rect x='662.41' y='279.81' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none;' />
+<rect x='663.12' y='280.52' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #5983AB; fill-opacity: 0.20;' />
+<text x='685.17' y='291.48' style='font-size: 8.80px; font-family: sans;' textLength='29.35px' lengthAdjust='spacingAndGlyphs'>95%CrI</text>
+<text x='39.77' y='16.23' style='font-size: 12.00px; font-family: sans;' textLength='65.37px' lengthAdjust='spacingAndGlyphs'>Estimated R</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/Darwin/plot/flu2009-ri.svg
+++ b/tests/testthat/_snaps/Darwin/plot/flu2009-ri.svg
@@ -1,0 +1,88 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzkuNzd8NjUxLjQ2fDMxLjE3fDUzMi4xOA=='>
+    <rect x='39.77' y='31.17' width='611.69' height='501.01' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzkuNzd8NjUxLjQ2fDMxLjE3fDUzMi4xOA==)'>
+<rect x='39.77' y='31.17' width='611.69' height='501.01' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='39.77,452.48 651.46,452.48 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,338.61 651.46,338.61 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,224.74 651.46,224.74 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,110.88 651.46,110.88 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='128.39,532.18 128.39,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='250.03,532.18 250.03,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='371.68,532.18 371.68,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='493.32,532.18 493.32,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='614.96,532.18 614.96,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,509.41 651.46,509.41 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,395.54 651.46,395.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,281.68 651.46,281.68 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,167.81 651.46,167.81 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,53.95 651.46,53.95 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='67.57,532.18 67.57,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='189.21,532.18 189.21,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='310.86,532.18 310.86,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='432.50,532.18 432.50,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='554.14,532.18 554.14,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polygon points='189.21,210.57 206.59,220.99 223.97,259.41 241.35,280.70 258.72,286.71 276.10,262.87 293.48,264.57 310.86,276.48 328.23,304.44 345.61,311.03 362.99,333.89 380.37,356.60 397.74,375.71 415.12,390.61 432.50,406.44 449.88,418.30 467.25,428.26 484.63,428.83 502.01,432.78 519.39,446.17 536.76,449.50 554.14,402.64 571.52,351.86 588.90,308.03 606.27,275.24 606.27,472.29 588.90,477.49 571.52,484.43 554.14,492.48 536.76,501.96 519.39,495.78 502.01,484.10 484.63,477.01 467.25,472.64 449.88,462.66 432.50,451.82 415.12,438.56 397.74,426.73 380.37,412.67 362.99,397.28 345.61,383.06 328.23,383.12 310.86,368.69 293.48,368.37 276.10,375.24 258.72,398.63 241.35,401.09 223.97,396.15 206.59,383.16 189.21,392.28 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #5983AB; fill-opacity: 0.20;' />
+<polyline points='189.21,210.57 206.59,220.99 223.97,259.41 241.35,280.70 258.72,286.71 276.10,262.87 293.48,264.57 310.86,276.48 328.23,304.44 345.61,311.03 362.99,333.89 380.37,356.60 397.74,375.71 415.12,390.61 432.50,406.44 449.88,418.30 467.25,428.26 484.63,428.83 502.01,432.78 519.39,446.17 536.76,449.50 554.14,402.64 571.52,351.86 588.90,308.03 606.27,275.24 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='606.27,472.29 588.90,477.49 571.52,484.43 554.14,492.48 536.76,501.96 519.39,495.78 502.01,484.10 484.63,477.01 467.25,472.64 449.88,462.66 432.50,451.82 415.12,438.56 397.74,426.73 380.37,412.67 362.99,397.28 345.61,383.06 328.23,383.12 310.86,368.69 293.48,368.37 276.10,375.24 258.72,398.63 241.35,401.09 223.97,396.15 206.59,383.16 189.21,392.28 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='189.21,311.78 206.59,310.25 223.97,334.39 241.35,346.39 258.72,347.45 276.10,323.24 293.48,319.98 310.86,325.44 328.23,346.12 345.61,349.04 362.99,367.33 380.37,386.21 397.74,402.72 415.12,416.10 432.50,430.75 449.88,442.29 467.25,452.60 484.63,455.59 502.01,461.89 519.39,475.51 536.76,482.08 554.14,457.28 571.52,432.49 588.90,411.10 606.27,395.09 ' style='stroke-width: 1.07; stroke: #5983AB; stroke-linecap: butt;' />
+<line x1='39.77' y1='395.54' x2='651.46' y2='395.54' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='39.77,532.18 39.77,31.17 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<text x='30.54' y='512.50' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='30.54' y='398.64' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='30.54' y='284.77' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='30.54' y='170.91' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='30.54' y='57.04' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>4</text>
+<polyline points='37.03,509.41 39.77,509.41 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,395.54 39.77,395.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,281.68 39.77,281.68 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,167.81 39.77,167.81 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,53.95 39.77,53.95 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='39.77,532.18 651.46,532.18 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<polyline points='67.57,534.92 67.57,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='189.21,534.92 189.21,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='310.86,534.92 310.86,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='432.50,534.92 432.50,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='554.14,534.92 554.14,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<text x='67.57' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='26.52px' lengthAdjust='spacingAndGlyphs'>Apr 27</text>
+<text x='189.21' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 04</text>
+<text x='310.86' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 11</text>
+<text x='432.50' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 18</text>
+<text x='554.14' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 25</text>
+<text x='345.61' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
+<text transform='translate(13.05,281.68) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='7.95px' lengthAdjust='spacingAndGlyphs'>R</text>
+<rect x='662.41' y='258.92' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none;' />
+<line x1='664.14' y1='267.56' x2='677.97' y2='267.56' style='stroke-width: 1.07; stroke: #5983AB; stroke-linecap: butt;' />
+<text x='685.17' y='270.59' style='font-size: 8.80px; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>Mean</text>
+<rect x='662.41' y='279.81' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none;' />
+<rect x='663.12' y='280.52' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #5983AB; fill-opacity: 0.20;' />
+<text x='685.17' y='291.48' style='font-size: 8.80px; font-family: sans;' textLength='29.35px' lengthAdjust='spacingAndGlyphs'>95%CrI</text>
+<text x='39.77' y='16.23' style='font-size: 12.00px; font-family: sans;' textLength='65.37px' lengthAdjust='spacingAndGlyphs'>Estimated R</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/Darwin/plot/flu2009-si.svg
+++ b/tests/testthat/_snaps/Darwin/plot/flu2009-si.svg
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDcuMjd8NzE0LjUyfDMxLjE3fDUzMi4xOA=='>
+    <rect x='47.27' y='31.17' width='667.25' height='501.01' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDcuMjd8NzE0LjUyfDMxLjE3fDUzMi4xOA==)'>
+<rect x='47.27' y='31.17' width='667.25' height='501.01' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='47.27,462.40 714.52,462.40 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='47.27,322.85 714.52,322.85 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='47.27,183.29 714.52,183.29 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='47.27,43.73 714.52,43.73 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='160.32,532.18 160.32,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='325.75,532.18 325.75,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='491.19,532.18 491.19,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='656.62,532.18 656.62,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='47.27,532.18 714.52,532.18 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='47.27,392.62 714.52,392.62 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='47.27,253.07 714.52,253.07 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='47.27,113.51 714.52,113.51 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='77.60,532.18 77.60,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='243.04,532.18 243.04,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='408.47,532.18 408.47,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='573.90,532.18 573.90,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='77.60,532.18 132.75,207.01 187.89,31.17 243.04,255.86 298.18,388.44 353.32,458.22 408.47,494.50 463.61,512.64 518.76,522.41 573.90,527.99 629.05,529.39 684.19,530.79 ' style='stroke-width: 1.07; stroke: #000000; stroke-opacity: 0.25; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='47.27,532.18 47.27,31.17 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<text x='34.29' y='535.28' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='34.29' y='395.72' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='34.29' y='256.16' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='34.29' y='116.61' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<polyline points='44.53,532.18 47.27,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='44.53,392.62 47.27,392.62 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='44.53,253.07 47.27,253.07 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='44.53,113.51 47.27,113.51 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='47.27,532.18 714.52,532.18 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<polyline points='77.60,534.92 77.60,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='243.04,534.92 243.04,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='408.47,534.92 408.47,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='573.90,534.92 573.90,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<text x='77.60' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='243.04' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='408.47' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='573.90' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>9</text>
+<text x='380.90' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
+<text transform='translate(13.05,281.68) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='51.98px' lengthAdjust='spacingAndGlyphs'>Frequency</text>
+<text x='47.27' y='16.23' style='font-size: 12.00px; font-family: sans;' textLength='123.41px' lengthAdjust='spacingAndGlyphs'>Explored SI distribution</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/Linux/plot/flu2009-incidence-import.svg
+++ b/tests/testthat/_snaps/Linux/plot/flu2009-incidence-import.svg
@@ -1,0 +1,145 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNTIuMjh8NzE0LjUyfDMxLjE3fDUzMi4xOA=='>
+    <rect x='52.28' y='31.17' width='662.24' height='501.01' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTIuMjh8NzE0LjUyfDMxLjE3fDUzMi4xOA==)'>
+<rect x='52.28' y='31.17' width='662.24' height='501.01' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='52.28,484.01 714.52,484.01 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,387.66 714.52,387.66 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,291.31 714.52,291.31 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,194.96 714.52,194.96 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,98.62 714.52,98.62 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='148.23,532.18 148.23,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='279.92,532.18 279.92,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='411.62,532.18 411.62,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='543.32,532.18 543.32,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='675.01,532.18 675.01,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,532.18 714.52,532.18 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,435.83 714.52,435.83 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,339.49 714.52,339.49 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,243.14 714.52,243.14 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,146.79 714.52,146.79 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,50.44 714.52,50.44 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='82.38,532.18 82.38,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='214.08,532.18 214.08,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='345.77,532.18 345.77,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='477.47,532.18 477.47,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='609.16,532.18 609.16,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<rect x='82.38' y='493.64' width='18.81' height='38.54' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='101.19' y='493.64' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='120.01' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='138.82' y='455.10' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='157.63' y='339.49' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='176.45' y='416.56' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='195.26' y='416.56' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='214.08' y='416.56' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='232.89' y='300.95' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='251.70' y='455.10' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='270.52' y='339.49' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='289.33' y='185.33' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='308.14' y='31.17' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='326.96' y='69.71' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='345.77' y='31.17' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='364.59' y='108.25' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='383.40' y='69.71' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='402.21' y='300.95' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='421.03' y='300.95' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='439.84' y='300.95' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='458.65' y='416.56' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='477.47' y='493.64' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='496.28' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='515.10' y='455.10' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='533.91' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='552.72' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='571.54' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='590.35' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='609.16' y='455.10' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='627.98' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='646.79' y='455.10' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='665.60' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='82.38' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='101.19' y='493.64' width='18.81' height='38.54' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='120.01' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='138.82' y='455.10' width='18.81' height='77.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='157.63' y='339.49' width='18.81' height='192.70' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='176.45' y='416.56' width='18.81' height='115.62' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='195.26' y='416.56' width='18.81' height='115.62' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='214.08' y='416.56' width='18.81' height='115.62' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='232.89' y='300.95' width='18.81' height='231.23' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='251.70' y='455.10' width='18.81' height='77.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='270.52' y='339.49' width='18.81' height='192.70' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='289.33' y='185.33' width='18.81' height='346.85' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='308.14' y='31.17' width='18.81' height='501.01' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='326.96' y='69.71' width='18.81' height='462.47' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='345.77' y='31.17' width='18.81' height='501.01' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='364.59' y='108.25' width='18.81' height='423.93' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='383.40' y='69.71' width='18.81' height='462.47' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='402.21' y='300.95' width='18.81' height='231.23' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='421.03' y='300.95' width='18.81' height='231.23' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='439.84' y='300.95' width='18.81' height='231.23' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='458.65' y='416.56' width='18.81' height='115.62' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='477.47' y='493.64' width='18.81' height='38.54' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='496.28' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='515.10' y='455.10' width='18.81' height='77.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='533.91' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='552.72' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='571.54' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='590.35' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='609.16' y='455.10' width='18.81' height='77.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='627.98' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='646.79' y='455.10' width='18.81' height='77.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='665.60' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='52.28,532.18 52.28,31.17 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<text x='36.79' y='535.28' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='36.79' y='438.93' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='36.79' y='342.58' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<text x='36.79' y='246.23' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>7.5</text>
+<text x='36.79' y='149.89' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='17.52px' lengthAdjust='spacingAndGlyphs'>10.0</text>
+<text x='36.79' y='53.54' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='17.52px' lengthAdjust='spacingAndGlyphs'>12.5</text>
+<polyline points='49.54,532.18 52.28,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='49.54,435.83 52.28,435.83 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='49.54,339.49 52.28,339.49 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='49.54,243.14 52.28,243.14 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='49.54,146.79 52.28,146.79 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='49.54,50.44 52.28,50.44 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='52.28,532.18 714.52,532.18 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<polyline points='82.38,534.92 82.38,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='214.08,534.92 214.08,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='345.77,534.92 345.77,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='477.47,534.92 477.47,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='609.16,534.92 609.16,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<text x='82.38' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-04-27</text>
+<text x='214.08' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-04</text>
+<text x='345.77' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-11</text>
+<text x='477.47' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-18</text>
+<text x='609.16' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-25</text>
+<text x='383.40' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
+<text transform='translate(13.05,281.68) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='47.10px' lengthAdjust='spacingAndGlyphs'>Incidence</text>
+<text x='52.28' y='16.23' style='font-size: 12.00px; font-family: sans;' textLength='82.05px' lengthAdjust='spacingAndGlyphs'>Epidemic curve</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/Linux/plot/flu2009-instantaneous-no-legend.svg
+++ b/tests/testthat/_snaps/Linux/plot/flu2009-instantaneous-no-legend.svg
@@ -1,0 +1,253 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNTcuNzZ8NzA5LjA0fDUzLjk2fDUyNi43MA=='>
+    <rect x='57.76' y='53.96' width='651.28' height='472.75' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTcuNzZ8NzA5LjA0fDUzLjk2fDUyNi43MA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8MjIuNzh8MjA1LjM2'>
+    <rect x='5.48' y='22.78' width='709.04' height='182.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8MjIuNzh8MjA1LjM2)'>
+<rect x='5.48' y='22.78' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA=='>
+    <rect x='5.48' y='205.36' width='709.04' height='182.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA==)'>
+<rect x='5.48' y='205.36' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg=='>
+    <rect x='5.48' y='387.94' width='709.04' height='182.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg==)'>
+<rect x='5.48' y='387.94' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTcuNzZ8NzA5LjA0fDUzLjk2fDE2MS41NA=='>
+    <rect x='57.76' y='53.96' width='651.28' height='107.59' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTcuNzZ8NzA5LjA0fDUzLjk2fDE2MS41NA==)'>
+<rect x='57.76' y='53.96' width='651.28' height='107.59' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='57.76,151.20 709.04,151.20 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,130.51 709.04,130.51 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,109.82 709.04,109.82 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,89.13 709.04,89.13 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,68.44 709.04,68.44 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='152.12,161.54 152.12,53.96 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='281.64,161.54 281.64,53.96 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='411.15,161.54 411.15,53.96 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='540.67,161.54 540.67,53.96 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='670.19,161.54 670.19,53.96 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,161.54 709.04,161.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,140.85 709.04,140.85 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,120.16 709.04,120.16 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,99.47 709.04,99.47 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,78.78 709.04,78.78 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,58.09 709.04,58.09 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='87.36,161.54 87.36,53.96 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='216.88,161.54 216.88,53.96 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='346.39,161.54 346.39,53.96 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='475.91,161.54 475.91,53.96 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='605.43,161.54 605.43,53.96 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<rect x='87.36' y='153.27' width='18.50' height='8.28' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='105.86' y='153.27' width='18.50' height='8.28' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='124.37' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='142.87' y='144.99' width='18.50' height='16.55' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='161.37' y='120.16' width='18.50' height='41.38' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='179.87' y='136.72' width='18.50' height='24.83' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='198.38' y='136.72' width='18.50' height='24.83' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='216.88' y='136.72' width='18.50' height='24.83' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='235.38' y='111.89' width='18.50' height='49.66' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='253.88' y='144.99' width='18.50' height='16.55' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='272.39' y='120.16' width='18.50' height='41.38' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='290.89' y='87.06' width='18.50' height='74.48' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='309.39' y='53.96' width='18.50' height='107.59' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='327.89' y='62.23' width='18.50' height='99.31' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='346.39' y='53.96' width='18.50' height='107.59' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='364.90' y='70.51' width='18.50' height='91.04' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='383.40' y='62.23' width='18.50' height='99.31' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='401.90' y='111.89' width='18.50' height='49.66' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='420.40' y='111.89' width='18.50' height='49.66' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='438.91' y='111.89' width='18.50' height='49.66' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='457.41' y='136.72' width='18.50' height='24.83' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='475.91' y='153.27' width='18.50' height='8.28' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='494.41' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='512.92' y='144.99' width='18.50' height='16.55' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='531.42' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='549.92' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='568.42' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='586.93' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='605.43' y='144.99' width='18.50' height='16.55' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='623.93' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='642.43' y='144.99' width='18.50' height='16.55' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='660.93' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='57.76,161.54 57.76,53.96 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<text x='42.27' y='164.64' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='42.27' y='143.95' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='42.27' y='123.26' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<text x='42.27' y='102.57' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>7.5</text>
+<text x='42.27' y='81.88' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='17.52px' lengthAdjust='spacingAndGlyphs'>10.0</text>
+<text x='42.27' y='61.19' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='17.52px' lengthAdjust='spacingAndGlyphs'>12.5</text>
+<polyline points='55.02,161.54 57.76,161.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,140.85 57.76,140.85 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,120.16 57.76,120.16 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,99.47 57.76,99.47 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,78.78 57.76,78.78 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,58.09 57.76,58.09 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='57.76,161.54 709.04,161.54 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<polyline points='87.36,164.28 87.36,161.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='216.88,164.28 216.88,161.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='346.39,164.28 346.39,161.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='475.91,164.28 475.91,161.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='605.43,164.28 605.43,161.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<text x='87.36' y='176.39' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-04-27</text>
+<text x='216.88' y='176.39' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-04</text>
+<text x='346.39' y='176.39' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-11</text>
+<text x='475.91' y='176.39' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-18</text>
+<text x='605.43' y='176.39' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-25</text>
+<text x='383.40' y='197.60' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
+<text transform='translate(18.53,107.75) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='47.10px' lengthAdjust='spacingAndGlyphs'>Incidence</text>
+<text x='57.76' y='39.01' style='font-size: 12.00px; font-family: sans;' textLength='82.05px' lengthAdjust='spacingAndGlyphs'>Epidemic curve</text>
+</g>
+<defs>
+  <clipPath id='cpNTcuNzZ8NzA5LjA0fDIzNi41NHwzNDQuMTI='>
+    <rect x='57.76' y='236.54' width='651.28' height='107.59' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTcuNzZ8NzA5LjA0fDIzNi41NHwzNDQuMTI=)'>
+<rect x='57.76' y='236.54' width='651.28' height='107.59' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='57.76,320.60 709.04,320.60 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,283.33 709.04,283.33 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,246.07 709.04,246.07 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='152.12,344.12 152.12,236.54 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='281.64,344.12 281.64,236.54 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='411.15,344.12 411.15,236.54 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='540.67,344.12 540.67,236.54 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='670.19,344.12 670.19,236.54 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,339.23 709.04,339.23 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,301.97 709.04,301.97 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,264.70 709.04,264.70 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='87.36,344.12 87.36,236.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='216.88,344.12 216.88,236.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='346.39,344.12 346.39,236.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='475.91,344.12 475.91,236.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='605.43,344.12 605.43,236.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polygon points='216.88,241.43 235.38,244.84 253.88,257.41 272.39,264.38 290.89,266.35 309.39,258.54 327.89,259.10 346.39,263.00 364.90,272.15 383.40,274.31 401.90,281.79 420.40,289.22 438.91,295.47 457.41,300.35 475.91,305.53 494.41,309.41 512.92,312.67 531.42,312.86 549.92,314.15 568.42,318.53 586.93,319.63 605.43,304.29 623.93,287.67 642.43,273.32 660.93,262.59 660.93,327.08 642.43,328.78 623.93,331.06 605.43,333.69 586.93,336.80 568.42,334.77 549.92,330.95 531.42,328.63 512.92,327.20 494.41,323.93 475.91,320.38 457.41,316.04 438.91,312.17 420.40,307.57 401.90,302.54 383.40,297.88 364.90,297.90 346.39,293.18 327.89,293.07 309.39,295.32 290.89,302.98 272.39,303.78 253.88,302.16 235.38,297.91 216.88,300.90 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #5983AB; fill-opacity: 0.20;' />
+<polyline points='216.88,241.43 235.38,244.84 253.88,257.41 272.39,264.38 290.89,266.35 309.39,258.54 327.89,259.10 346.39,263.00 364.90,272.15 383.40,274.31 401.90,281.79 420.40,289.22 438.91,295.47 457.41,300.35 475.91,305.53 494.41,309.41 512.92,312.67 531.42,312.86 549.92,314.15 568.42,318.53 586.93,319.63 605.43,304.29 623.93,287.67 642.43,273.32 660.93,262.59 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='660.93,327.08 642.43,328.78 623.93,331.06 605.43,333.69 586.93,336.80 568.42,334.77 549.92,330.95 531.42,328.63 512.92,327.20 494.41,323.93 475.91,320.38 457.41,316.04 438.91,312.17 420.40,307.57 401.90,302.54 383.40,297.88 364.90,297.90 346.39,293.18 327.89,293.07 309.39,295.32 290.89,302.98 272.39,303.78 253.88,302.16 235.38,297.91 216.88,300.90 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='216.88,274.55 235.38,274.05 253.88,281.95 272.39,285.88 290.89,286.23 309.39,278.30 327.89,277.23 346.39,279.02 364.90,285.79 383.40,286.75 401.90,292.73 420.40,298.91 438.91,304.32 457.41,308.69 475.91,313.49 494.41,317.27 512.92,320.64 531.42,321.62 549.92,323.68 568.42,328.14 586.93,330.29 605.43,322.17 623.93,314.06 642.43,307.06 660.93,301.82 ' style='stroke-width: 1.07; stroke: #5983AB; stroke-linecap: butt;' />
+<line x1='57.76' y1='301.97' x2='709.04' y2='301.97' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='57.76,344.12 57.76,236.54 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<text x='42.27' y='342.33' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='42.27' y='305.06' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='42.27' y='267.80' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>2</text>
+<polyline points='55.02,339.23 57.76,339.23 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,301.97 57.76,301.97 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,264.70 57.76,264.70 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='57.76,344.12 709.04,344.12 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<polyline points='87.36,346.86 87.36,344.12 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='216.88,346.86 216.88,344.12 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='346.39,346.86 346.39,344.12 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='475.91,346.86 475.91,344.12 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='605.43,346.86 605.43,344.12 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<text x='87.36' y='358.97' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='26.52px' lengthAdjust='spacingAndGlyphs'>Apr 27</text>
+<text x='216.88' y='358.97' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 04</text>
+<text x='346.39' y='358.97' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 11</text>
+<text x='475.91' y='358.97' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 18</text>
+<text x='605.43' y='358.97' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 25</text>
+<text x='383.40' y='380.18' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
+<text transform='translate(18.53,290.33) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='7.95px' lengthAdjust='spacingAndGlyphs'>R</text>
+<text x='57.76' y='221.59' style='font-size: 12.00px; font-family: sans;' textLength='65.37px' lengthAdjust='spacingAndGlyphs'>Estimated R</text>
+</g>
+<defs>
+  <clipPath id='cpNTcuNzZ8NzA5LjA0fDQxOS4xMXw1MjYuNzA='>
+    <rect x='57.76' y='419.11' width='651.28' height='107.59' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTcuNzZ8NzA5LjA0fDQxOS4xMXw1MjYuNzA=)'>
+<rect x='57.76' y='419.11' width='651.28' height='107.59' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='57.76,511.72 709.04,511.72 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,481.75 709.04,481.75 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,451.78 709.04,451.78 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,421.81 709.04,421.81 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='168.10,526.70 168.10,419.11 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='329.57,526.70 329.57,419.11 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='491.05,526.70 491.05,419.11 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='652.52,526.70 652.52,419.11 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,526.70 709.04,526.70 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,496.73 709.04,496.73 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,466.76 709.04,466.76 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,436.80 709.04,436.80 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='87.36,526.70 87.36,419.11 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='248.84,526.70 248.84,419.11 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='410.31,526.70 410.31,419.11 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='571.79,526.70 571.79,419.11 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='87.36,526.70 141.19,456.87 195.01,419.11 248.84,467.36 302.66,495.83 356.49,510.82 410.31,518.61 464.14,522.51 517.96,524.60 571.79,525.80 625.61,526.10 679.44,526.40 ' style='stroke-width: 1.07; stroke: #000000; stroke-opacity: 0.25; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='57.76,526.70 57.76,419.11 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<text x='42.27' y='529.80' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='42.27' y='499.83' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='42.27' y='469.86' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='42.27' y='439.89' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<polyline points='55.02,526.70 57.76,526.70 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,496.73 57.76,496.73 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,466.76 57.76,466.76 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,436.80 57.76,436.80 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='57.76,526.70 709.04,526.70 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<polyline points='87.36,529.44 87.36,526.70 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='248.84,529.44 248.84,526.70 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='410.31,529.44 410.31,526.70 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='571.79,529.44 571.79,526.70 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<text x='87.36' y='541.55' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='248.84' y='541.55' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='410.31' y='541.55' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='571.79' y='541.55' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>9</text>
+<text x='383.40' y='562.76' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
+<text transform='translate(18.53,472.91) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='51.98px' lengthAdjust='spacingAndGlyphs'>Frequency</text>
+<text x='57.76' y='404.17' style='font-size: 12.00px; font-family: sans;' textLength='123.41px' lengthAdjust='spacingAndGlyphs'>Explored SI distribution</text>
+<text x='10.96' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='197.42px' lengthAdjust='spacingAndGlyphs'>Flu2009-instantaneous-no-legend</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/Linux/plot/flu2009-rc.svg
+++ b/tests/testthat/_snaps/Linux/plot/flu2009-rc.svg
@@ -1,0 +1,88 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzkuNzd8NjUxLjQ2fDMxLjE3fDUzMi4xOA=='>
+    <rect x='39.77' y='31.17' width='611.69' height='501.01' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzkuNzd8NjUxLjQ2fDMxLjE3fDUzMi4xOA==)'>
+<rect x='39.77' y='31.17' width='611.69' height='501.01' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='39.77,452.48 651.46,452.48 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,338.61 651.46,338.61 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,224.74 651.46,224.74 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,110.88 651.46,110.88 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='128.39,532.18 128.39,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='250.03,532.18 250.03,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='371.68,532.18 371.68,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='493.32,532.18 493.32,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='614.96,532.18 614.96,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,509.41 651.46,509.41 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,395.54 651.46,395.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,281.68 651.46,281.68 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,167.81 651.46,167.81 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,53.95 651.46,53.95 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='67.57,532.18 67.57,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='189.21,532.18 189.21,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='310.86,532.18 310.86,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='432.50,532.18 432.50,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='554.14,532.18 554.14,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polygon points='189.21,304.79 206.59,313.90 223.97,320.70 241.35,328.07 258.72,308.22 276.10,330.14 293.48,340.66 310.86,360.34 328.23,371.24 345.61,386.96 362.99,403.03 380.37,415.82 397.74,429.10 415.12,436.39 432.50,446.72 449.88,449.88 467.25,453.54 484.63,452.48 502.01,452.48 519.39,433.50 536.76,395.54 554.14,395.54 571.52,395.54 588.90,452.48 606.27,452.48 606.27,452.48 588.90,452.48 571.52,446.07 554.14,446.07 536.76,492.33 519.39,500.87 502.01,478.81 484.63,476.36 467.25,475.13 449.88,471.82 432.50,469.18 415.12,462.76 397.74,441.74 380.37,429.51 362.99,412.85 345.61,401.62 328.23,389.89 310.86,376.14 293.48,363.66 276.10,349.86 258.72,336.77 241.35,352.42 223.97,362.81 206.59,367.33 189.21,364.23 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #5983AB; fill-opacity: 0.20;' />
+<polyline points='189.21,304.79 206.59,313.90 223.97,320.70 241.35,328.07 258.72,308.22 276.10,330.14 293.48,340.66 310.86,360.34 328.23,371.24 345.61,386.96 362.99,403.03 380.37,415.82 397.74,429.10 415.12,436.39 432.50,446.72 449.88,449.88 467.25,453.54 484.63,452.48 502.01,452.48 519.39,433.50 536.76,395.54 554.14,395.54 571.52,395.54 588.90,452.48 606.27,452.48 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='606.27,452.48 588.90,452.48 571.52,446.07 554.14,446.07 536.76,492.33 519.39,500.87 502.01,478.81 484.63,476.36 467.25,475.13 449.88,471.82 432.50,469.18 415.12,462.76 397.74,441.74 380.37,429.51 362.99,412.85 345.61,401.62 328.23,389.89 310.86,376.14 293.48,363.66 276.10,349.86 258.72,336.77 241.35,352.42 223.97,362.81 206.59,367.33 189.21,364.23 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='189.21,334.66 206.59,343.57 223.97,339.00 241.35,337.33 258.72,330.56 276.10,342.17 293.48,355.58 310.86,368.94 328.23,382.71 345.61,395.76 362.99,407.39 380.37,421.19 397.74,435.17 415.12,444.85 432.50,453.20 449.88,458.85 467.25,462.14 484.63,466.37 502.01,468.63 519.39,459.84 536.76,443.36 554.14,419.50 571.52,419.50 588.90,455.69 606.27,455.69 ' style='stroke-width: 1.07; stroke: #5983AB; stroke-linecap: butt;' />
+<line x1='39.77' y1='395.54' x2='651.46' y2='395.54' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='39.77,532.18 39.77,31.17 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<text x='30.54' y='512.50' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='30.54' y='398.64' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='30.54' y='284.77' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='30.54' y='170.91' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='30.54' y='57.04' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>4</text>
+<polyline points='37.03,509.41 39.77,509.41 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,395.54 39.77,395.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,281.68 39.77,281.68 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,167.81 39.77,167.81 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,53.95 39.77,53.95 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='39.77,532.18 651.46,532.18 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<polyline points='67.57,534.92 67.57,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='189.21,534.92 189.21,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='310.86,534.92 310.86,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='432.50,534.92 432.50,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='554.14,534.92 554.14,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<text x='67.57' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='26.52px' lengthAdjust='spacingAndGlyphs'>Apr 27</text>
+<text x='189.21' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 04</text>
+<text x='310.86' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 11</text>
+<text x='432.50' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 18</text>
+<text x='554.14' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 25</text>
+<text x='345.61' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
+<text transform='translate(13.05,281.68) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='7.95px' lengthAdjust='spacingAndGlyphs'>R</text>
+<rect x='662.41' y='258.92' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none;' />
+<line x1='664.14' y1='267.56' x2='677.97' y2='267.56' style='stroke-width: 1.07; stroke: #5983AB; stroke-linecap: butt;' />
+<text x='685.17' y='270.59' style='font-size: 8.80px; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>Mean</text>
+<rect x='662.41' y='279.81' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none;' />
+<rect x='663.12' y='280.52' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #5983AB; fill-opacity: 0.20;' />
+<text x='685.17' y='291.48' style='font-size: 8.80px; font-family: sans;' textLength='29.35px' lengthAdjust='spacingAndGlyphs'>95%CrI</text>
+<text x='39.77' y='16.23' style='font-size: 12.00px; font-family: sans;' textLength='65.37px' lengthAdjust='spacingAndGlyphs'>Estimated R</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/Linux/plot/flu2009-ri.svg
+++ b/tests/testthat/_snaps/Linux/plot/flu2009-ri.svg
@@ -1,0 +1,88 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzkuNzd8NjUxLjQ2fDMxLjE3fDUzMi4xOA=='>
+    <rect x='39.77' y='31.17' width='611.69' height='501.01' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzkuNzd8NjUxLjQ2fDMxLjE3fDUzMi4xOA==)'>
+<rect x='39.77' y='31.17' width='611.69' height='501.01' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='39.77,452.48 651.46,452.48 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,338.61 651.46,338.61 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,224.74 651.46,224.74 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,110.88 651.46,110.88 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='128.39,532.18 128.39,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='250.03,532.18 250.03,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='371.68,532.18 371.68,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='493.32,532.18 493.32,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='614.96,532.18 614.96,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,509.41 651.46,509.41 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,395.54 651.46,395.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,281.68 651.46,281.68 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,167.81 651.46,167.81 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,53.95 651.46,53.95 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='67.57,532.18 67.57,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='189.21,532.18 189.21,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='310.86,532.18 310.86,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='432.50,532.18 432.50,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='554.14,532.18 554.14,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polygon points='189.21,210.57 206.59,220.99 223.97,259.41 241.35,280.70 258.72,286.71 276.10,262.87 293.48,264.57 310.86,276.48 328.23,304.44 345.61,311.03 362.99,333.89 380.37,356.60 397.74,375.71 415.12,390.61 432.50,406.44 449.88,418.30 467.25,428.26 484.63,428.83 502.01,432.78 519.39,446.17 536.76,449.50 554.14,402.64 571.52,351.86 588.90,308.03 606.27,275.24 606.27,472.29 588.90,477.49 571.52,484.43 554.14,492.48 536.76,501.96 519.39,495.78 502.01,484.10 484.63,477.01 467.25,472.64 449.88,462.66 432.50,451.82 415.12,438.56 397.74,426.73 380.37,412.67 362.99,397.28 345.61,383.06 328.23,383.12 310.86,368.69 293.48,368.37 276.10,375.24 258.72,398.63 241.35,401.09 223.97,396.15 206.59,383.16 189.21,392.28 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #5983AB; fill-opacity: 0.20;' />
+<polyline points='189.21,210.57 206.59,220.99 223.97,259.41 241.35,280.70 258.72,286.71 276.10,262.87 293.48,264.57 310.86,276.48 328.23,304.44 345.61,311.03 362.99,333.89 380.37,356.60 397.74,375.71 415.12,390.61 432.50,406.44 449.88,418.30 467.25,428.26 484.63,428.83 502.01,432.78 519.39,446.17 536.76,449.50 554.14,402.64 571.52,351.86 588.90,308.03 606.27,275.24 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='606.27,472.29 588.90,477.49 571.52,484.43 554.14,492.48 536.76,501.96 519.39,495.78 502.01,484.10 484.63,477.01 467.25,472.64 449.88,462.66 432.50,451.82 415.12,438.56 397.74,426.73 380.37,412.67 362.99,397.28 345.61,383.06 328.23,383.12 310.86,368.69 293.48,368.37 276.10,375.24 258.72,398.63 241.35,401.09 223.97,396.15 206.59,383.16 189.21,392.28 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='189.21,311.78 206.59,310.25 223.97,334.39 241.35,346.39 258.72,347.45 276.10,323.24 293.48,319.98 310.86,325.44 328.23,346.12 345.61,349.04 362.99,367.33 380.37,386.21 397.74,402.72 415.12,416.10 432.50,430.75 449.88,442.29 467.25,452.60 484.63,455.59 502.01,461.89 519.39,475.51 536.76,482.08 554.14,457.28 571.52,432.49 588.90,411.10 606.27,395.09 ' style='stroke-width: 1.07; stroke: #5983AB; stroke-linecap: butt;' />
+<line x1='39.77' y1='395.54' x2='651.46' y2='395.54' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='39.77,532.18 39.77,31.17 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<text x='30.54' y='512.50' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='30.54' y='398.64' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='30.54' y='284.77' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='30.54' y='170.91' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='30.54' y='57.04' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>4</text>
+<polyline points='37.03,509.41 39.77,509.41 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,395.54 39.77,395.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,281.68 39.77,281.68 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,167.81 39.77,167.81 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,53.95 39.77,53.95 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='39.77,532.18 651.46,532.18 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<polyline points='67.57,534.92 67.57,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='189.21,534.92 189.21,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='310.86,534.92 310.86,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='432.50,534.92 432.50,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='554.14,534.92 554.14,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<text x='67.57' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='26.52px' lengthAdjust='spacingAndGlyphs'>Apr 27</text>
+<text x='189.21' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 04</text>
+<text x='310.86' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 11</text>
+<text x='432.50' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 18</text>
+<text x='554.14' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 25</text>
+<text x='345.61' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
+<text transform='translate(13.05,281.68) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='7.95px' lengthAdjust='spacingAndGlyphs'>R</text>
+<rect x='662.41' y='258.92' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none;' />
+<line x1='664.14' y1='267.56' x2='677.97' y2='267.56' style='stroke-width: 1.07; stroke: #5983AB; stroke-linecap: butt;' />
+<text x='685.17' y='270.59' style='font-size: 8.80px; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>Mean</text>
+<rect x='662.41' y='279.81' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none;' />
+<rect x='663.12' y='280.52' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #5983AB; fill-opacity: 0.20;' />
+<text x='685.17' y='291.48' style='font-size: 8.80px; font-family: sans;' textLength='29.35px' lengthAdjust='spacingAndGlyphs'>95%CrI</text>
+<text x='39.77' y='16.23' style='font-size: 12.00px; font-family: sans;' textLength='65.37px' lengthAdjust='spacingAndGlyphs'>Estimated R</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/Linux/plot/flu2009-si.svg
+++ b/tests/testthat/_snaps/Linux/plot/flu2009-si.svg
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDcuMjd8NzE0LjUyfDMxLjE3fDUzMi4xOA=='>
+    <rect x='47.27' y='31.17' width='667.25' height='501.01' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDcuMjd8NzE0LjUyfDMxLjE3fDUzMi4xOA==)'>
+<rect x='47.27' y='31.17' width='667.25' height='501.01' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='47.27,462.40 714.52,462.40 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='47.27,322.85 714.52,322.85 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='47.27,183.29 714.52,183.29 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='47.27,43.73 714.52,43.73 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='160.32,532.18 160.32,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='325.75,532.18 325.75,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='491.19,532.18 491.19,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='656.62,532.18 656.62,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='47.27,532.18 714.52,532.18 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='47.27,392.62 714.52,392.62 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='47.27,253.07 714.52,253.07 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='47.27,113.51 714.52,113.51 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='77.60,532.18 77.60,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='243.04,532.18 243.04,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='408.47,532.18 408.47,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='573.90,532.18 573.90,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='77.60,532.18 132.75,207.01 187.89,31.17 243.04,255.86 298.18,388.44 353.32,458.22 408.47,494.50 463.61,512.64 518.76,522.41 573.90,527.99 629.05,529.39 684.19,530.79 ' style='stroke-width: 1.07; stroke: #000000; stroke-opacity: 0.25; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='47.27,532.18 47.27,31.17 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<text x='34.29' y='535.28' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='34.29' y='395.72' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='34.29' y='256.16' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='34.29' y='116.61' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<polyline points='44.53,532.18 47.27,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='44.53,392.62 47.27,392.62 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='44.53,253.07 47.27,253.07 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='44.53,113.51 47.27,113.51 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='47.27,532.18 714.52,532.18 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<polyline points='77.60,534.92 77.60,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='243.04,534.92 243.04,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='408.47,534.92 408.47,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='573.90,534.92 573.90,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<text x='77.60' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='243.04' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='408.47' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='573.90' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>9</text>
+<text x='380.90' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
+<text transform='translate(13.05,281.68) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='51.98px' lengthAdjust='spacingAndGlyphs'>Frequency</text>
+<text x='47.27' y='16.23' style='font-size: 12.00px; font-family: sans;' textLength='123.41px' lengthAdjust='spacingAndGlyphs'>Explored SI distribution</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/Windows/plot/flu2009-incidence-import.svg
+++ b/tests/testthat/_snaps/Windows/plot/flu2009-incidence-import.svg
@@ -1,0 +1,145 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNTIuMjh8NzE0LjUyfDMxLjE3fDUzMi4xOA=='>
+    <rect x='52.28' y='31.17' width='662.24' height='501.01' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTIuMjh8NzE0LjUyfDMxLjE3fDUzMi4xOA==)'>
+<rect x='52.28' y='31.17' width='662.24' height='501.01' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='52.28,484.01 714.52,484.01 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,387.66 714.52,387.66 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,291.31 714.52,291.31 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,194.96 714.52,194.96 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,98.62 714.52,98.62 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='148.23,532.18 148.23,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='279.92,532.18 279.92,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='411.62,532.18 411.62,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='543.32,532.18 543.32,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='675.01,532.18 675.01,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,532.18 714.52,532.18 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,435.83 714.52,435.83 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,339.49 714.52,339.49 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,243.14 714.52,243.14 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,146.79 714.52,146.79 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='52.28,50.44 714.52,50.44 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='82.38,532.18 82.38,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='214.08,532.18 214.08,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='345.77,532.18 345.77,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='477.47,532.18 477.47,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='609.16,532.18 609.16,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<rect x='82.38' y='493.64' width='18.81' height='38.54' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='101.19' y='493.64' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='120.01' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='138.82' y='455.10' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='157.63' y='339.49' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='176.45' y='416.56' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='195.26' y='416.56' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='214.08' y='416.56' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='232.89' y='300.95' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='251.70' y='455.10' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='270.52' y='339.49' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='289.33' y='185.33' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='308.14' y='31.17' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='326.96' y='69.71' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='345.77' y='31.17' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='364.59' y='108.25' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='383.40' y='69.71' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='402.21' y='300.95' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='421.03' y='300.95' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='439.84' y='300.95' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='458.65' y='416.56' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='477.47' y='493.64' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='496.28' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='515.10' y='455.10' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='533.91' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='552.72' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='571.54' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='590.35' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='609.16' y='455.10' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='627.98' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='646.79' y='455.10' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='665.60' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #AA3939; fill-opacity: 0.70;' />
+<rect x='82.38' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='101.19' y='493.64' width='18.81' height='38.54' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='120.01' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='138.82' y='455.10' width='18.81' height='77.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='157.63' y='339.49' width='18.81' height='192.70' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='176.45' y='416.56' width='18.81' height='115.62' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='195.26' y='416.56' width='18.81' height='115.62' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='214.08' y='416.56' width='18.81' height='115.62' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='232.89' y='300.95' width='18.81' height='231.23' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='251.70' y='455.10' width='18.81' height='77.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='270.52' y='339.49' width='18.81' height='192.70' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='289.33' y='185.33' width='18.81' height='346.85' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='308.14' y='31.17' width='18.81' height='501.01' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='326.96' y='69.71' width='18.81' height='462.47' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='345.77' y='31.17' width='18.81' height='501.01' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='364.59' y='108.25' width='18.81' height='423.93' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='383.40' y='69.71' width='18.81' height='462.47' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='402.21' y='300.95' width='18.81' height='231.23' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='421.03' y='300.95' width='18.81' height='231.23' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='439.84' y='300.95' width='18.81' height='231.23' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='458.65' y='416.56' width='18.81' height='115.62' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='477.47' y='493.64' width='18.81' height='38.54' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='496.28' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='515.10' y='455.10' width='18.81' height='77.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='533.91' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='552.72' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='571.54' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='590.35' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='609.16' y='455.10' width='18.81' height='77.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='627.98' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='646.79' y='455.10' width='18.81' height='77.08' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+<rect x='665.60' y='532.18' width='18.81' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #4A6A8A; fill-opacity: 0.70;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='52.28,532.18 52.28,31.17 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<text x='36.79' y='535.28' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='36.79' y='438.93' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='36.79' y='342.58' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<text x='36.79' y='246.23' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>7.5</text>
+<text x='36.79' y='149.89' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='17.52px' lengthAdjust='spacingAndGlyphs'>10.0</text>
+<text x='36.79' y='53.54' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='17.52px' lengthAdjust='spacingAndGlyphs'>12.5</text>
+<polyline points='49.54,532.18 52.28,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='49.54,435.83 52.28,435.83 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='49.54,339.49 52.28,339.49 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='49.54,243.14 52.28,243.14 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='49.54,146.79 52.28,146.79 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='49.54,50.44 52.28,50.44 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='52.28,532.18 714.52,532.18 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<polyline points='82.38,534.92 82.38,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='214.08,534.92 214.08,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='345.77,534.92 345.77,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='477.47,534.92 477.47,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='609.16,534.92 609.16,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<text x='82.38' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-04-27</text>
+<text x='214.08' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-04</text>
+<text x='345.77' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-11</text>
+<text x='477.47' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-18</text>
+<text x='609.16' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-25</text>
+<text x='383.40' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
+<text transform='translate(13.05,281.68) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='47.10px' lengthAdjust='spacingAndGlyphs'>Incidence</text>
+<text x='52.28' y='16.23' style='font-size: 12.00px; font-family: sans;' textLength='82.05px' lengthAdjust='spacingAndGlyphs'>Epidemic curve</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/Windows/plot/flu2009-instantaneous-no-legend.svg
+++ b/tests/testthat/_snaps/Windows/plot/flu2009-instantaneous-no-legend.svg
@@ -1,0 +1,253 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNTcuNzZ8NzA5LjA0fDUzLjk2fDUyNi43MA=='>
+    <rect x='57.76' y='53.96' width='651.28' height='472.75' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTcuNzZ8NzA5LjA0fDUzLjk2fDUyNi43MA==)'>
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8MjIuNzh8MjA1LjM2'>
+    <rect x='5.48' y='22.78' width='709.04' height='182.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8MjIuNzh8MjA1LjM2)'>
+<rect x='5.48' y='22.78' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA=='>
+    <rect x='5.48' y='205.36' width='709.04' height='182.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8MjA1LjM2fDM4Ny45NA==)'>
+<rect x='5.48' y='205.36' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg=='>
+    <rect x='5.48' y='387.94' width='709.04' height='182.58' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNS40OHw3MTQuNTJ8Mzg3Ljk0fDU3MC41Mg==)'>
+<rect x='5.48' y='387.94' width='709.04' height='182.58' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+</g>
+<defs>
+  <clipPath id='cpNTcuNzZ8NzA5LjA0fDUzLjk2fDE2MS41NA=='>
+    <rect x='57.76' y='53.96' width='651.28' height='107.59' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTcuNzZ8NzA5LjA0fDUzLjk2fDE2MS41NA==)'>
+<rect x='57.76' y='53.96' width='651.28' height='107.59' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='57.76,151.20 709.04,151.20 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,130.51 709.04,130.51 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,109.82 709.04,109.82 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,89.13 709.04,89.13 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,68.44 709.04,68.44 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='152.12,161.54 152.12,53.96 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='281.64,161.54 281.64,53.96 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='411.15,161.54 411.15,53.96 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='540.67,161.54 540.67,53.96 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='670.19,161.54 670.19,53.96 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,161.54 709.04,161.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,140.85 709.04,140.85 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,120.16 709.04,120.16 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,99.47 709.04,99.47 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,78.78 709.04,78.78 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,58.09 709.04,58.09 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='87.36,161.54 87.36,53.96 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='216.88,161.54 216.88,53.96 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='346.39,161.54 346.39,53.96 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='475.91,161.54 475.91,53.96 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='605.43,161.54 605.43,53.96 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<rect x='87.36' y='153.27' width='18.50' height='8.28' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='105.86' y='153.27' width='18.50' height='8.28' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='124.37' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='142.87' y='144.99' width='18.50' height='16.55' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='161.37' y='120.16' width='18.50' height='41.38' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='179.87' y='136.72' width='18.50' height='24.83' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='198.38' y='136.72' width='18.50' height='24.83' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='216.88' y='136.72' width='18.50' height='24.83' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='235.38' y='111.89' width='18.50' height='49.66' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='253.88' y='144.99' width='18.50' height='16.55' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='272.39' y='120.16' width='18.50' height='41.38' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='290.89' y='87.06' width='18.50' height='74.48' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='309.39' y='53.96' width='18.50' height='107.59' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='327.89' y='62.23' width='18.50' height='99.31' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='346.39' y='53.96' width='18.50' height='107.59' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='364.90' y='70.51' width='18.50' height='91.04' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='383.40' y='62.23' width='18.50' height='99.31' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='401.90' y='111.89' width='18.50' height='49.66' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='420.40' y='111.89' width='18.50' height='49.66' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='438.91' y='111.89' width='18.50' height='49.66' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='457.41' y='136.72' width='18.50' height='24.83' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='475.91' y='153.27' width='18.50' height='8.28' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='494.41' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='512.92' y='144.99' width='18.50' height='16.55' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='531.42' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='549.92' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='568.42' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='586.93' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='605.43' y='144.99' width='18.50' height='16.55' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='623.93' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='642.43' y='144.99' width='18.50' height='16.55' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+<rect x='660.93' y='161.54' width='18.50' height='0.00' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; stroke-linejoin: miter; fill: #5983AB; fill-opacity: 0.70;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='57.76,161.54 57.76,53.96 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<text x='42.27' y='164.64' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='42.27' y='143.95' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>2.5</text>
+<text x='42.27' y='123.26' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>5.0</text>
+<text x='42.27' y='102.57' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>7.5</text>
+<text x='42.27' y='81.88' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='17.52px' lengthAdjust='spacingAndGlyphs'>10.0</text>
+<text x='42.27' y='61.19' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='17.52px' lengthAdjust='spacingAndGlyphs'>12.5</text>
+<polyline points='55.02,161.54 57.76,161.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,140.85 57.76,140.85 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,120.16 57.76,120.16 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,99.47 57.76,99.47 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,78.78 57.76,78.78 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,58.09 57.76,58.09 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='57.76,161.54 709.04,161.54 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<polyline points='87.36,164.28 87.36,161.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='216.88,164.28 216.88,161.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='346.39,164.28 346.39,161.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='475.91,164.28 475.91,161.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='605.43,164.28 605.43,161.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<text x='87.36' y='176.39' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-04-27</text>
+<text x='216.88' y='176.39' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-04</text>
+<text x='346.39' y='176.39' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-11</text>
+<text x='475.91' y='176.39' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-18</text>
+<text x='605.43' y='176.39' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='46.04px' lengthAdjust='spacingAndGlyphs'>2009-05-25</text>
+<text x='383.40' y='197.60' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
+<text transform='translate(18.53,107.75) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='47.10px' lengthAdjust='spacingAndGlyphs'>Incidence</text>
+<text x='57.76' y='39.01' style='font-size: 12.00px; font-family: sans;' textLength='82.05px' lengthAdjust='spacingAndGlyphs'>Epidemic curve</text>
+</g>
+<defs>
+  <clipPath id='cpNTcuNzZ8NzA5LjA0fDIzNi41NHwzNDQuMTI='>
+    <rect x='57.76' y='236.54' width='651.28' height='107.59' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTcuNzZ8NzA5LjA0fDIzNi41NHwzNDQuMTI=)'>
+<rect x='57.76' y='236.54' width='651.28' height='107.59' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='57.76,320.60 709.04,320.60 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,283.33 709.04,283.33 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,246.07 709.04,246.07 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='152.12,344.12 152.12,236.54 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='281.64,344.12 281.64,236.54 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='411.15,344.12 411.15,236.54 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='540.67,344.12 540.67,236.54 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='670.19,344.12 670.19,236.54 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,339.23 709.04,339.23 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,301.97 709.04,301.97 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,264.70 709.04,264.70 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='87.36,344.12 87.36,236.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='216.88,344.12 216.88,236.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='346.39,344.12 346.39,236.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='475.91,344.12 475.91,236.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='605.43,344.12 605.43,236.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polygon points='216.88,241.43 235.38,244.84 253.88,257.41 272.39,264.38 290.89,266.35 309.39,258.54 327.89,259.10 346.39,263.00 364.90,272.15 383.40,274.31 401.90,281.79 420.40,289.22 438.91,295.47 457.41,300.35 475.91,305.53 494.41,309.41 512.92,312.67 531.42,312.86 549.92,314.15 568.42,318.53 586.93,319.63 605.43,304.29 623.93,287.67 642.43,273.32 660.93,262.59 660.93,327.08 642.43,328.78 623.93,331.06 605.43,333.69 586.93,336.80 568.42,334.77 549.92,330.95 531.42,328.63 512.92,327.20 494.41,323.93 475.91,320.38 457.41,316.04 438.91,312.17 420.40,307.57 401.90,302.54 383.40,297.88 364.90,297.90 346.39,293.18 327.89,293.07 309.39,295.32 290.89,302.98 272.39,303.78 253.88,302.16 235.38,297.91 216.88,300.90 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #5983AB; fill-opacity: 0.20;' />
+<polyline points='216.88,241.43 235.38,244.84 253.88,257.41 272.39,264.38 290.89,266.35 309.39,258.54 327.89,259.10 346.39,263.00 364.90,272.15 383.40,274.31 401.90,281.79 420.40,289.22 438.91,295.47 457.41,300.35 475.91,305.53 494.41,309.41 512.92,312.67 531.42,312.86 549.92,314.15 568.42,318.53 586.93,319.63 605.43,304.29 623.93,287.67 642.43,273.32 660.93,262.59 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='660.93,327.08 642.43,328.78 623.93,331.06 605.43,333.69 586.93,336.80 568.42,334.77 549.92,330.95 531.42,328.63 512.92,327.20 494.41,323.93 475.91,320.38 457.41,316.04 438.91,312.17 420.40,307.57 401.90,302.54 383.40,297.88 364.90,297.90 346.39,293.18 327.89,293.07 309.39,295.32 290.89,302.98 272.39,303.78 253.88,302.16 235.38,297.91 216.88,300.90 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='216.88,274.55 235.38,274.05 253.88,281.95 272.39,285.88 290.89,286.23 309.39,278.30 327.89,277.23 346.39,279.02 364.90,285.79 383.40,286.75 401.90,292.73 420.40,298.91 438.91,304.32 457.41,308.69 475.91,313.49 494.41,317.27 512.92,320.64 531.42,321.62 549.92,323.68 568.42,328.14 586.93,330.29 605.43,322.17 623.93,314.06 642.43,307.06 660.93,301.82 ' style='stroke-width: 1.07; stroke: #5983AB; stroke-linecap: butt;' />
+<line x1='57.76' y1='301.97' x2='709.04' y2='301.97' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='57.76,344.12 57.76,236.54 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<text x='42.27' y='342.33' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='42.27' y='305.06' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='42.27' y='267.80' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>2</text>
+<polyline points='55.02,339.23 57.76,339.23 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,301.97 57.76,301.97 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,264.70 57.76,264.70 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='57.76,344.12 709.04,344.12 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<polyline points='87.36,346.86 87.36,344.12 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='216.88,346.86 216.88,344.12 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='346.39,346.86 346.39,344.12 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='475.91,346.86 475.91,344.12 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='605.43,346.86 605.43,344.12 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<text x='87.36' y='358.97' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='26.52px' lengthAdjust='spacingAndGlyphs'>Apr 27</text>
+<text x='216.88' y='358.97' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 04</text>
+<text x='346.39' y='358.97' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 11</text>
+<text x='475.91' y='358.97' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 18</text>
+<text x='605.43' y='358.97' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 25</text>
+<text x='383.40' y='380.18' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
+<text transform='translate(18.53,290.33) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='7.95px' lengthAdjust='spacingAndGlyphs'>R</text>
+<text x='57.76' y='221.59' style='font-size: 12.00px; font-family: sans;' textLength='65.37px' lengthAdjust='spacingAndGlyphs'>Estimated R</text>
+</g>
+<defs>
+  <clipPath id='cpNTcuNzZ8NzA5LjA0fDQxOS4xMXw1MjYuNzA='>
+    <rect x='57.76' y='419.11' width='651.28' height='107.59' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNTcuNzZ8NzA5LjA0fDQxOS4xMXw1MjYuNzA=)'>
+<rect x='57.76' y='419.11' width='651.28' height='107.59' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='57.76,511.72 709.04,511.72 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,481.75 709.04,481.75 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,451.78 709.04,451.78 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,421.81 709.04,421.81 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='168.10,526.70 168.10,419.11 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='329.57,526.70 329.57,419.11 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='491.05,526.70 491.05,419.11 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='652.52,526.70 652.52,419.11 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,526.70 709.04,526.70 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,496.73 709.04,496.73 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,466.76 709.04,466.76 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='57.76,436.80 709.04,436.80 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='87.36,526.70 87.36,419.11 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='248.84,526.70 248.84,419.11 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='410.31,526.70 410.31,419.11 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='571.79,526.70 571.79,419.11 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='87.36,526.70 141.19,456.87 195.01,419.11 248.84,467.36 302.66,495.83 356.49,510.82 410.31,518.61 464.14,522.51 517.96,524.60 571.79,525.80 625.61,526.10 679.44,526.40 ' style='stroke-width: 1.07; stroke: #000000; stroke-opacity: 0.25; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='57.76,526.70 57.76,419.11 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<text x='42.27' y='529.80' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='42.27' y='499.83' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='42.27' y='469.86' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='42.27' y='439.89' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<polyline points='55.02,526.70 57.76,526.70 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,496.73 57.76,496.73 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,466.76 57.76,466.76 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='55.02,436.80 57.76,436.80 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='57.76,526.70 709.04,526.70 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<polyline points='87.36,529.44 87.36,526.70 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='248.84,529.44 248.84,526.70 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='410.31,529.44 410.31,526.70 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='571.79,529.44 571.79,526.70 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<text x='87.36' y='541.55' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='248.84' y='541.55' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='410.31' y='541.55' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='571.79' y='541.55' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>9</text>
+<text x='383.40' y='562.76' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
+<text transform='translate(18.53,472.91) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='51.98px' lengthAdjust='spacingAndGlyphs'>Frequency</text>
+<text x='57.76' y='404.17' style='font-size: 12.00px; font-family: sans;' textLength='123.41px' lengthAdjust='spacingAndGlyphs'>Explored SI distribution</text>
+<text x='10.96' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='197.42px' lengthAdjust='spacingAndGlyphs'>Flu2009-instantaneous-no-legend</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/Windows/plot/flu2009-rc.svg
+++ b/tests/testthat/_snaps/Windows/plot/flu2009-rc.svg
@@ -1,0 +1,88 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzkuNzd8NjUxLjQ2fDMxLjE3fDUzMi4xOA=='>
+    <rect x='39.77' y='31.17' width='611.69' height='501.01' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzkuNzd8NjUxLjQ2fDMxLjE3fDUzMi4xOA==)'>
+<rect x='39.77' y='31.17' width='611.69' height='501.01' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='39.77,452.48 651.46,452.48 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,338.61 651.46,338.61 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,224.74 651.46,224.74 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,110.88 651.46,110.88 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='128.39,532.18 128.39,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='250.03,532.18 250.03,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='371.68,532.18 371.68,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='493.32,532.18 493.32,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='614.96,532.18 614.96,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,509.41 651.46,509.41 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,395.54 651.46,395.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,281.68 651.46,281.68 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,167.81 651.46,167.81 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,53.95 651.46,53.95 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='67.57,532.18 67.57,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='189.21,532.18 189.21,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='310.86,532.18 310.86,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='432.50,532.18 432.50,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='554.14,532.18 554.14,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polygon points='189.21,304.79 206.59,313.90 223.97,320.70 241.35,328.07 258.72,308.22 276.10,330.14 293.48,340.66 310.86,360.34 328.23,371.24 345.61,386.96 362.99,403.03 380.37,415.82 397.74,429.10 415.12,436.39 432.50,446.72 449.88,449.88 467.25,453.54 484.63,452.48 502.01,452.48 519.39,433.50 536.76,395.54 554.14,395.54 571.52,395.54 588.90,452.48 606.27,452.48 606.27,452.48 588.90,452.48 571.52,446.07 554.14,446.07 536.76,492.33 519.39,500.87 502.01,478.81 484.63,476.36 467.25,475.13 449.88,471.82 432.50,469.18 415.12,462.76 397.74,441.74 380.37,429.51 362.99,412.85 345.61,401.62 328.23,389.89 310.86,376.14 293.48,363.66 276.10,349.86 258.72,336.77 241.35,352.42 223.97,362.81 206.59,367.33 189.21,364.23 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #5983AB; fill-opacity: 0.20;' />
+<polyline points='189.21,304.79 206.59,313.90 223.97,320.70 241.35,328.07 258.72,308.22 276.10,330.14 293.48,340.66 310.86,360.34 328.23,371.24 345.61,386.96 362.99,403.03 380.37,415.82 397.74,429.10 415.12,436.39 432.50,446.72 449.88,449.88 467.25,453.54 484.63,452.48 502.01,452.48 519.39,433.50 536.76,395.54 554.14,395.54 571.52,395.54 588.90,452.48 606.27,452.48 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='606.27,452.48 588.90,452.48 571.52,446.07 554.14,446.07 536.76,492.33 519.39,500.87 502.01,478.81 484.63,476.36 467.25,475.13 449.88,471.82 432.50,469.18 415.12,462.76 397.74,441.74 380.37,429.51 362.99,412.85 345.61,401.62 328.23,389.89 310.86,376.14 293.48,363.66 276.10,349.86 258.72,336.77 241.35,352.42 223.97,362.81 206.59,367.33 189.21,364.23 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='189.21,334.66 206.59,343.57 223.97,339.00 241.35,337.33 258.72,330.56 276.10,342.17 293.48,355.58 310.86,368.94 328.23,382.71 345.61,395.76 362.99,407.39 380.37,421.19 397.74,435.17 415.12,444.85 432.50,453.20 449.88,458.85 467.25,462.14 484.63,466.37 502.01,468.63 519.39,459.84 536.76,443.36 554.14,419.50 571.52,419.50 588.90,455.69 606.27,455.69 ' style='stroke-width: 1.07; stroke: #5983AB; stroke-linecap: butt;' />
+<line x1='39.77' y1='395.54' x2='651.46' y2='395.54' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='39.77,532.18 39.77,31.17 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<text x='30.54' y='512.50' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='30.54' y='398.64' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='30.54' y='284.77' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='30.54' y='170.91' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='30.54' y='57.04' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>4</text>
+<polyline points='37.03,509.41 39.77,509.41 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,395.54 39.77,395.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,281.68 39.77,281.68 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,167.81 39.77,167.81 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,53.95 39.77,53.95 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='39.77,532.18 651.46,532.18 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<polyline points='67.57,534.92 67.57,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='189.21,534.92 189.21,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='310.86,534.92 310.86,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='432.50,534.92 432.50,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='554.14,534.92 554.14,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<text x='67.57' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='26.52px' lengthAdjust='spacingAndGlyphs'>Apr 27</text>
+<text x='189.21' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 04</text>
+<text x='310.86' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 11</text>
+<text x='432.50' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 18</text>
+<text x='554.14' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 25</text>
+<text x='345.61' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
+<text transform='translate(13.05,281.68) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='7.95px' lengthAdjust='spacingAndGlyphs'>R</text>
+<rect x='662.41' y='258.92' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none;' />
+<line x1='664.14' y1='267.56' x2='677.97' y2='267.56' style='stroke-width: 1.07; stroke: #5983AB; stroke-linecap: butt;' />
+<text x='685.17' y='270.59' style='font-size: 8.80px; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>Mean</text>
+<rect x='662.41' y='279.81' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none;' />
+<rect x='663.12' y='280.52' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #5983AB; fill-opacity: 0.20;' />
+<text x='685.17' y='291.48' style='font-size: 8.80px; font-family: sans;' textLength='29.35px' lengthAdjust='spacingAndGlyphs'>95%CrI</text>
+<text x='39.77' y='16.23' style='font-size: 12.00px; font-family: sans;' textLength='65.37px' lengthAdjust='spacingAndGlyphs'>Estimated R</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/Windows/plot/flu2009-ri.svg
+++ b/tests/testthat/_snaps/Windows/plot/flu2009-ri.svg
@@ -1,0 +1,88 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzkuNzd8NjUxLjQ2fDMxLjE3fDUzMi4xOA=='>
+    <rect x='39.77' y='31.17' width='611.69' height='501.01' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzkuNzd8NjUxLjQ2fDMxLjE3fDUzMi4xOA==)'>
+<rect x='39.77' y='31.17' width='611.69' height='501.01' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='39.77,452.48 651.46,452.48 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,338.61 651.46,338.61 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,224.74 651.46,224.74 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,110.88 651.46,110.88 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='128.39,532.18 128.39,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='250.03,532.18 250.03,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='371.68,532.18 371.68,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='493.32,532.18 493.32,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='614.96,532.18 614.96,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,509.41 651.46,509.41 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,395.54 651.46,395.54 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,281.68 651.46,281.68 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,167.81 651.46,167.81 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='39.77,53.95 651.46,53.95 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='67.57,532.18 67.57,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='189.21,532.18 189.21,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='310.86,532.18 310.86,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='432.50,532.18 432.50,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='554.14,532.18 554.14,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polygon points='189.21,210.57 206.59,220.99 223.97,259.41 241.35,280.70 258.72,286.71 276.10,262.87 293.48,264.57 310.86,276.48 328.23,304.44 345.61,311.03 362.99,333.89 380.37,356.60 397.74,375.71 415.12,390.61 432.50,406.44 449.88,418.30 467.25,428.26 484.63,428.83 502.01,432.78 519.39,446.17 536.76,449.50 554.14,402.64 571.52,351.86 588.90,308.03 606.27,275.24 606.27,472.29 588.90,477.49 571.52,484.43 554.14,492.48 536.76,501.96 519.39,495.78 502.01,484.10 484.63,477.01 467.25,472.64 449.88,462.66 432.50,451.82 415.12,438.56 397.74,426.73 380.37,412.67 362.99,397.28 345.61,383.06 328.23,383.12 310.86,368.69 293.48,368.37 276.10,375.24 258.72,398.63 241.35,401.09 223.97,396.15 206.59,383.16 189.21,392.28 ' style='stroke-width: 0.00; stroke: none; stroke-linecap: butt; fill: #5983AB; fill-opacity: 0.20;' />
+<polyline points='189.21,210.57 206.59,220.99 223.97,259.41 241.35,280.70 258.72,286.71 276.10,262.87 293.48,264.57 310.86,276.48 328.23,304.44 345.61,311.03 362.99,333.89 380.37,356.60 397.74,375.71 415.12,390.61 432.50,406.44 449.88,418.30 467.25,428.26 484.63,428.83 502.01,432.78 519.39,446.17 536.76,449.50 554.14,402.64 571.52,351.86 588.90,308.03 606.27,275.24 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='606.27,472.29 588.90,477.49 571.52,484.43 554.14,492.48 536.76,501.96 519.39,495.78 502.01,484.10 484.63,477.01 467.25,472.64 449.88,462.66 432.50,451.82 415.12,438.56 397.74,426.73 380.37,412.67 362.99,397.28 345.61,383.06 328.23,383.12 310.86,368.69 293.48,368.37 276.10,375.24 258.72,398.63 241.35,401.09 223.97,396.15 206.59,383.16 189.21,392.28 ' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<polyline points='189.21,311.78 206.59,310.25 223.97,334.39 241.35,346.39 258.72,347.45 276.10,323.24 293.48,319.98 310.86,325.44 328.23,346.12 345.61,349.04 362.99,367.33 380.37,386.21 397.74,402.72 415.12,416.10 432.50,430.75 449.88,442.29 467.25,452.60 484.63,455.59 502.01,461.89 519.39,475.51 536.76,482.08 554.14,457.28 571.52,432.49 588.90,411.10 606.27,395.09 ' style='stroke-width: 1.07; stroke: #5983AB; stroke-linecap: butt;' />
+<line x1='39.77' y1='395.54' x2='651.46' y2='395.54' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='39.77,532.18 39.77,31.17 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<text x='30.54' y='512.50' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='30.54' y='398.64' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='30.54' y='284.77' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='30.54' y='170.91' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='30.54' y='57.04' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>4</text>
+<polyline points='37.03,509.41 39.77,509.41 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,395.54 39.77,395.54 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,281.68 39.77,281.68 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,167.81 39.77,167.81 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='37.03,53.95 39.77,53.95 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='39.77,532.18 651.46,532.18 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<polyline points='67.57,534.92 67.57,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='189.21,534.92 189.21,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='310.86,534.92 310.86,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='432.50,534.92 432.50,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='554.14,534.92 554.14,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<text x='67.57' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='26.52px' lengthAdjust='spacingAndGlyphs'>Apr 27</text>
+<text x='189.21' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 04</text>
+<text x='310.86' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 11</text>
+<text x='432.50' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 18</text>
+<text x='554.14' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='29.52px' lengthAdjust='spacingAndGlyphs'>May 25</text>
+<text x='345.61' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
+<text transform='translate(13.05,281.68) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='7.95px' lengthAdjust='spacingAndGlyphs'>R</text>
+<rect x='662.41' y='258.92' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none;' />
+<line x1='664.14' y1='267.56' x2='677.97' y2='267.56' style='stroke-width: 1.07; stroke: #5983AB; stroke-linecap: butt;' />
+<text x='685.17' y='270.59' style='font-size: 8.80px; font-family: sans;' textLength='22.02px' lengthAdjust='spacingAndGlyphs'>Mean</text>
+<rect x='662.41' y='279.81' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none;' />
+<rect x='663.12' y='280.52' width='15.86' height='15.86' style='stroke-width: 1.07; stroke: none; stroke-linecap: butt; fill: #5983AB; fill-opacity: 0.20;' />
+<text x='685.17' y='291.48' style='font-size: 8.80px; font-family: sans;' textLength='29.35px' lengthAdjust='spacingAndGlyphs'>95%CrI</text>
+<text x='39.77' y='16.23' style='font-size: 12.00px; font-family: sans;' textLength='65.37px' lengthAdjust='spacingAndGlyphs'>Estimated R</text>
+</g>
+</svg>

--- a/tests/testthat/_snaps/Windows/plot/flu2009-si.svg
+++ b/tests/testthat/_snaps/Windows/plot/flu2009-si.svg
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpNDcuMjd8NzE0LjUyfDMxLjE3fDUzMi4xOA=='>
+    <rect x='47.27' y='31.17' width='667.25' height='501.01' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpNDcuMjd8NzE0LjUyfDMxLjE3fDUzMi4xOA==)'>
+<rect x='47.27' y='31.17' width='667.25' height='501.01' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<polyline points='47.27,462.40 714.52,462.40 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='47.27,322.85 714.52,322.85 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='47.27,183.29 714.52,183.29 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='47.27,43.73 714.52,43.73 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='160.32,532.18 160.32,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='325.75,532.18 325.75,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='491.19,532.18 491.19,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='656.62,532.18 656.62,31.17 ' style='stroke-width: 0.27; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='47.27,532.18 714.52,532.18 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='47.27,392.62 714.52,392.62 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='47.27,253.07 714.52,253.07 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='47.27,113.51 714.52,113.51 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='77.60,532.18 77.60,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='243.04,532.18 243.04,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='408.47,532.18 408.47,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='573.90,532.18 573.90,31.17 ' style='stroke-width: 0.53; stroke: #DEDEDE; stroke-linecap: butt;' />
+<polyline points='77.60,532.18 132.75,207.01 187.89,31.17 243.04,255.86 298.18,388.44 353.32,458.22 408.47,494.50 463.61,512.64 518.76,522.41 573.90,527.99 629.05,529.39 684.19,530.79 ' style='stroke-width: 1.07; stroke: #000000; stroke-opacity: 0.25; stroke-linecap: butt;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<polyline points='47.27,532.18 47.27,31.17 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<text x='34.29' y='535.28' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.0</text>
+<text x='34.29' y='395.72' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.1</text>
+<text x='34.29' y='256.16' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.2</text>
+<text x='34.29' y='116.61' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='12.51px' lengthAdjust='spacingAndGlyphs'>0.3</text>
+<polyline points='44.53,532.18 47.27,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='44.53,392.62 47.27,392.62 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='44.53,253.07 47.27,253.07 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='44.53,113.51 47.27,113.51 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='47.27,532.18 714.52,532.18 ' style='stroke-width: 0.43; stroke-linecap: butt;' />
+<polyline points='77.60,534.92 77.60,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='243.04,534.92 243.04,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='408.47,534.92 408.47,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<polyline points='573.90,534.92 573.90,532.18 ' style='stroke-width: 0.53; stroke: #B3B3B3; stroke-linecap: butt;' />
+<text x='77.60' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='243.04' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>3</text>
+<text x='408.47' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>6</text>
+<text x='573.90' y='547.03' text-anchor='middle' style='font-size: 9.00px; font-family: sans;' textLength='5.01px' lengthAdjust='spacingAndGlyphs'>9</text>
+<text x='380.90' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='24.45px' lengthAdjust='spacingAndGlyphs'>Time</text>
+<text transform='translate(13.05,281.68) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='51.98px' lengthAdjust='spacingAndGlyphs'>Frequency</text>
+<text x='47.27' y='16.23' style='font-size: 12.00px; font-family: sans;' textLength='123.41px' lengthAdjust='spacingAndGlyphs'>Explored SI distribution</text>
+</g>
+</svg>

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -20,36 +20,46 @@ R_c <- wallinga_teunis(
                 )
 )
 
-test_that("plot.estimate_R doesn't have to include the legend", {
-  skip("vdiffr tests not working - see #106")
-  skip_if_not_installed("vdiffr")
-  vdiffr::expect_doppelganger("Flu2009-instantaneous-no-legend", 
-                              plot(R_i, legend = FALSE))
+# Create snapshots by system, prevent fragility across developers
+system <- Sys.info()[["sysname"]]
 
+test_that("plot.estimate_R doesn't have to include the legend", {
+  skip_if_not_installed("vdiffr")
+  vdiffr::expect_doppelganger(
+    "Flu2009-instantaneous-no-legend", 
+    plot(R_i, legend = FALSE),
+    variant = system
+  )
 })
 
 test_that("incidence can be plotted separately with imported cases", {
-  skip("vdiffr tests not working - see #106")
   skip_if_not_installed("vdiffr")
-  vdiffr::expect_doppelganger("Flu2009-incidence-import", 
-                              plot(R_i, "incid", add_imported_cases=TRUE))
-
+  vdiffr::expect_doppelganger(
+    "Flu2009-incidence-import", 
+    plot(R_i, "incid", add_imported_cases=TRUE),
+    variant = system
+  )
 })
 
 test_that("serial interval distribution can be plotted separately", {
-  skip("vdiffr tests not working - see #106")
   skip_if_not_installed("vdiffr")
-  vdiffr::expect_doppelganger("Flu2009-SI", 
-                              plot(R_i, "SI"))
-
+  vdiffr::expect_doppelganger(
+    "Flu2009-SI", 
+    plot(R_i, "SI"),
+    variant = system
+  )
 })
 
 test_that("Reproduction numbers can be plotted separately", {
-  skip("vdiffr tests not working - see #106")
   skip_if_not_installed("vdiffr")
-  vdiffr::expect_doppelganger("Flu2009-Ri", 
-                              plot(R_i, "R", options_R = list(ylim = c(0, 4))))
-  vdiffr::expect_doppelganger("Flu2009-Rc",
-                              plot(R_c, "R", options_R = list(ylim = c(0, 4))))
-
+  vdiffr::expect_doppelganger(
+    "Flu2009-Ri", 
+    plot(R_i, "R", options_R = list(ylim = c(0, 4))),
+    variant = system
+  )
+  vdiffr::expect_doppelganger(
+    "Flu2009-Rc",
+    plot(R_c, "R", options_R = list(ylim = c(0, 4))),
+    variant = system
+  )
 })

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -24,8 +24,7 @@ R_c <- wallinga_teunis(
 system <- Sys.info()[["sysname"]]
 
 test_that("plot.estimate_R doesn't have to include the legend", {
-  skip_if_not_installed("vdiffr")
-  vdiffr::expect_doppelganger(
+  epi_expect_doppelganger(
     "Flu2009-instantaneous-no-legend", 
     plot(R_i, legend = FALSE),
     variant = system
@@ -33,8 +32,7 @@ test_that("plot.estimate_R doesn't have to include the legend", {
 })
 
 test_that("incidence can be plotted separately with imported cases", {
-  skip_if_not_installed("vdiffr")
-  vdiffr::expect_doppelganger(
+  epi_expect_doppelganger(
     "Flu2009-incidence-import", 
     plot(R_i, "incid", add_imported_cases=TRUE),
     variant = system
@@ -42,8 +40,7 @@ test_that("incidence can be plotted separately with imported cases", {
 })
 
 test_that("serial interval distribution can be plotted separately", {
-  skip_if_not_installed("vdiffr")
-  vdiffr::expect_doppelganger(
+  epi_expect_doppelganger(
     "Flu2009-SI", 
     plot(R_i, "SI"),
     variant = system
@@ -51,13 +48,12 @@ test_that("serial interval distribution can be plotted separately", {
 })
 
 test_that("Reproduction numbers can be plotted separately", {
-  skip_if_not_installed("vdiffr")
-  vdiffr::expect_doppelganger(
+  epi_expect_doppelganger(
     "Flu2009-Ri", 
     plot(R_i, "R", options_R = list(ylim = c(0, 4))),
     variant = system
   )
-  vdiffr::expect_doppelganger(
+  epi_expect_doppelganger(
     "Flu2009-Rc",
     plot(R_c, "R", options_R = list(ylim = c(0, 4))),
     variant = system

--- a/tests/testthat/test-weekly.R
+++ b/tests/testthat/test-weekly.R
@@ -620,7 +620,7 @@ test_that("you can't run estimate_R_agg unless using parametric/non-parametric S
                  config = config,
                  method = method,
                  grid = list(precision = 0.001, min = -1, max = 1)),
-               "'arg' should be one of \"non_parametric_si\", \"parametric_si\"")
+               cat("'arg' should be one of \"non_parametric_si\", \"parametric_si\""))
   
 })
 

--- a/tests/testthat/test-weekly.R
+++ b/tests/testthat/test-weekly.R
@@ -620,7 +620,7 @@ test_that("you can't run estimate_R_agg unless using parametric/non-parametric S
                  config = config,
                  method = method,
                  grid = list(precision = 0.001, min = -1, max = 1)),
-               cat("'arg' should be one of \"non_parametric_si\", \"parametric_si\""))
+               "'arg' should be one of \"non_parametric_si\", \"parametric_si\"")
   
 })
 


### PR DESCRIPTION
* This PR fixes #106 
* I think time and updates to vdiffr more than anything I did fixed these tests
* These tests are snapshot tests, so save an svg version of the plots and compares future tests against these versions
* This means that the first version should be validated by someone who knows what it should look like
* These tests are only run locally (not on CI)
* I added a `variant` of System, so that different OS (Linux, Windows, MacOS) will compare against their own system-specific snapshots. I'm not sure if this is necessary, but it can be frustrating to get errors from minor wiggles.

> This needs a review of the SVG files to make sure they're as they should be.

**Checklist**
- [X] I have added tests to prove my changes work
- [X] I have added documentation where required
- [ ] ~~I have updated `NEWS.md` with a short description of my change~~
