### PR TITLE
Add parametric_si support in estimate_advantage

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: EpiEstim
-Version: 3.0.0
+Version: 3.0.1
 Title: Estimate Time Varying Reproduction Numbers from Epidemic Curves
 Authors@R: c(person("Anne", "Cori", email = "a.cori@imperial.ac.uk", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-8443-9162")), 
   person("Simon", "Cauchemez", role = "ctb"),
@@ -58,6 +58,6 @@ License: GPL (>=2)
 LazyLoad: yes
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 VignetteBuilder: knitr
 Remotes: reconverse/incidence2/pkg
+Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # EpiEstim 3.0.0
 
+* `estimate_advantage` now supports parametric serial interval specification.
+
+# EpiEstim 3.0.0
+
 ## New features
 
 - `wallinga_teunis()` is now an S3 generic with methods for `integer`,

--- a/R/gibbs_draws.R
+++ b/R/gibbs_draws.R
@@ -412,7 +412,7 @@ draw_R <- function(epsilon, incid, lambda, priors,
 #' @export
 
 compute_si_cutoff <- function(si_distr, miss_at_most = 0.05) {
-  if (any(colSums(si_distr) != 1)) {
+  if (any(abs(colSums(si_distr) - 1) > 0.01)) {
     warning("Input SI distributions should sum to 1. Normalising now")
     si_distr <- si_distr / colSums(si_distr)
   }
@@ -477,6 +477,60 @@ compute_t_min <- function(incid, si_distr, miss_at_most) {
   as.integer(t_min_incid + t_min_si)
 }
 
+build_advantage_si_distr <- function(method, si_distr = NULL, mean_si = NULL,
+                                     std_si = NULL, n_v = NULL, T = NULL) {
+  method <- match.arg(method, c("non_parametric_si", "parametric_si"))
+
+  if (is.null(n_v) || is.null(T)) {
+    stop("n_v and T must be provided.")
+  }
+
+  if (method == "non_parametric_si") {
+    if (is.null(si_distr)) {
+      stop("si_distr must be supplied when method = 'non_parametric_si'.")
+    }
+    if (!is.matrix(si_distr)) {
+      si_distr <- as.matrix(si_distr)
+    }
+    return(si_distr)
+  }
+
+  if (!is.null(si_distr)) {
+    stop("si_distr should not be supplied when method = 'parametric_si'.")
+  }
+  if (is.null(mean_si)) {
+    stop("mean_si must be supplied when method = 'parametric_si'.")
+  }
+  if (is.null(std_si)) {
+    stop("std_si must be supplied when method = 'parametric_si'.")
+  }
+  if (any(mean_si <= 1)) {
+    stop("All values in mean_si must be > 1.")
+  }
+  if (any(std_si <= 0)) {
+    stop("All values in std_si must be > 0.")
+  }
+
+  if (length(mean_si) == 1L) {
+    mean_si <- rep(mean_si, n_v)
+  }
+  if (length(std_si) == 1L) {
+    std_si <- rep(std_si, n_v)
+  }
+  if (length(mean_si) != n_v || length(std_si) != n_v) {
+    stop("mean_si and std_si must each have length 1 or n_v.")
+  }
+
+  si_mat <- matrix(NA_real_, nrow = T, ncol = n_v)
+  for (k in seq_len(n_v)) {
+    col <- discr_si(seq(0, T - 1), mean_si[k], std_si[k])
+    col <- col / sum(col)
+    si_mat[, k] <- col
+  }
+
+  si_mat
+}
+
 #' Estimate instantaneous reproduction number
 #' 
 #' Jointly estimate the instantaneous reproduction number for a reference
@@ -487,11 +541,11 @@ compute_t_min <- function(incid, si_distr, miss_at_most) {
 #'   for each time step (1st dimension), location (2nd dimension) and
 #'   pathogen/strain/variant (3rd dimension)
 #'
-#' @param si_distr a matrix with two columns, each containing the probability mass
-#'   function for the discrete serial interval for each of the two
-#'   pathogen/strain/variants, starting with the probability mass function
-#'   for day 0 in the first row, which should be 0. Each column in the matrix
-#'   should sum to 1.
+#' @param si_distr a matrix containing the probability mass function for the
+#'   discrete serial interval for each pathogen/strain/variant, starting with
+#'   the probability mass function for day 0 in the first row, which should be
+#'   0. Each column in the matrix should sum to 1. Used when
+#'   `method = "non_parametric_si"`.
 #'
 #' @param priors a list of prior parameters (shape and scale of a gamma
 #'   distribution) for epsilon and R; can be obtained from the function
@@ -528,6 +582,16 @@ compute_t_min <- function(incid, si_distr, miss_at_most) {
 #'   transmission advantage. If `TRUE`, the most transmissible pathogen/strain/variant
 #'   is temporarily assigned to `[, , 1]` of the incidence array. We recommend the
 #'   default value of `TRUE` as we find this to stabilise inference.
+#'
+#' @param method one of `"non_parametric_si"` or `"parametric_si"`.
+#'
+#' @param mean_si mean serial interval(s) used when `method = "parametric_si"`.
+#'   May be a single value, recycled across all variants, or one value per
+#'   variant.
+#'
+#' @param std_si standard deviation(s) of the serial interval used when
+#'   `method = "parametric_si"`. May be a single value, recycled across all
+#'   variants, or one value per variant.
 #'
 #' @return A list with the following elements:
 #' - `epsilon`: a matrix containing the MCMC chain (thinned and after burnin)
@@ -581,13 +645,29 @@ compute_t_min <- function(incid, si_distr, miss_at_most) {
 #' plot(x$R[30, 3, ], type = "l",
 #'      xlab = "Iteration", ylab = "R time 30 location 3")
 
-estimate_advantage <- function(incid, si_distr, priors = default_priors(),
+estimate_advantage <- function(incid, si_distr = NULL, priors = default_priors(),
                            mcmc_control = default_mcmc_controls(),
                            t_min = NULL, t_max = nrow(incid),
                            seed = NULL,
                            incid_imported = NULL,
                            precompute = TRUE,
-                           reorder_incid = TRUE) {
+                           reorder_incid = TRUE,
+                           method = c("non_parametric_si", "parametric_si"),
+                           mean_si = NULL,
+                           std_si = NULL) {
+
+  method <- match.arg(method)
+  T <- nrow(incid)
+  n_v <- dim(incid)[3]
+
+  si_distr <- build_advantage_si_distr(
+    method = method,
+    si_distr = si_distr,
+    mean_si = mean_si,
+    std_si = std_si,
+    n_v = n_v,
+    T = T
+  )
 
   if (is.null(t_min)) {
     t_min <- compute_t_min(incid, si_distr)
@@ -822,4 +902,3 @@ process_I_multivariant <- function(incid, incid_imported = NULL) {
 
 ## TODO: check dimensions of objects is correct everywhere
 ## TODO: fix number of variants to be 2
-

--- a/R/gibbs_draws.R
+++ b/R/gibbs_draws.R
@@ -413,7 +413,7 @@ draw_R <- function(epsilon, incid, lambda, priors,
 
 compute_si_cutoff <- function(si_distr, miss_at_most = 0.05) {
   if (any(abs(colSums(si_distr) - 1) > 0.01)) {
-    warning("Input SI distributions should sum to 1. Normalising now")
+    warning("Input SI distributions should sum to 1. Normalising now", call. = FALSE)
     si_distr <- si_distr / colSums(si_distr)
   }
   cutoff <- 1 - miss_at_most
@@ -438,7 +438,6 @@ compute_si_cutoff <- function(si_distr, miss_at_most = 0.05) {
 #' @author Sangeeta Bhatia
 #' 
 #' @export
-
 first_nonzero_incid <- function(incid) {
   t_min_incid <- apply(
     incid, c(2, 3),
@@ -470,45 +469,54 @@ first_nonzero_incid <- function(incid) {
 #' @author Sangeeta Bhatia
 #' 
 #' @export
-
 compute_t_min <- function(incid, si_distr, miss_at_most) {
   t_min_si <- compute_si_cutoff(si_distr, 0.05)
   t_min_incid <- first_nonzero_incid(incid)
   as.integer(t_min_incid + t_min_si)
 }
 
+#' Build a discrete serial interval matrix for [estimate_advantage()]
+#'
+#' @inheritParams estimate_advantage
+#' @inheritParams compute_t_min
+#' @param method the serial interval specification to use.
+#'
+#' @noRd
 build_advantage_si_distr <- function(method, si_distr = NULL, mean_si = NULL,
                                      std_si = NULL, n_v = NULL, T = NULL) {
   method <- match.arg(method, c("non_parametric_si", "parametric_si"))
 
   if (is.null(n_v) || is.null(T)) {
-    stop("n_v and T must be provided.")
+    stop("n_v and T must be provided.", call. = FALSE)
   }
 
   if (method == "non_parametric_si") {
     if (is.null(si_distr)) {
-      stop("si_distr must be supplied when method = 'non_parametric_si'.")
+      stop("si_distr must be supplied when method = 'non_parametric_si'.", call. = FALSE)
     }
     if (!is.matrix(si_distr)) {
-      si_distr <- as.matrix(si_distr)
+      stop(
+        "si_distr must be supplied as a matrix when method = 'non_parametric_si'.",
+        call. = FALSE
+      )
     }
     return(si_distr)
   }
 
   if (!is.null(si_distr)) {
-    stop("si_distr should not be supplied when method = 'parametric_si'.")
+    stop("si_distr should not be supplied when method = 'parametric_si'.", call. = FALSE)
   }
   if (is.null(mean_si)) {
-    stop("mean_si must be supplied when method = 'parametric_si'.")
+    stop("mean_si must be supplied when method = 'parametric_si'.", call. = FALSE)
   }
   if (is.null(std_si)) {
-    stop("std_si must be supplied when method = 'parametric_si'.")
+    stop("std_si must be supplied when method = 'parametric_si'.", call. = FALSE)
   }
   if (any(mean_si <= 1)) {
-    stop("All values in mean_si must be > 1.")
+    stop("All values in mean_si must be > 1.", call. = FALSE)
   }
   if (any(std_si <= 0)) {
-    stop("All values in std_si must be > 0.")
+    stop("All values in std_si must be > 0.", call. = FALSE)
   }
 
   if (length(mean_si) == 1L) {
@@ -518,14 +526,14 @@ build_advantage_si_distr <- function(method, si_distr = NULL, mean_si = NULL,
     std_si <- rep(std_si, n_v)
   }
   if (length(mean_si) != n_v || length(std_si) != n_v) {
-    stop("mean_si and std_si must each have length 1 or n_v.")
+    stop("mean_si and std_si must each have length 1 or n_v.", call. = FALSE)
   }
 
   si_mat <- matrix(NA_real_, nrow = T, ncol = n_v)
   for (k in seq_len(n_v)) {
-    col <- discr_si(seq(0, T - 1), mean_si[k], std_si[k])
-    col <- col / sum(col)
-    si_mat[, k] <- col
+    column <- discr_si(seq(0, T - 1), mean_si[k], std_si[k])
+    column <- column / sum(column)
+    si_mat[, k] <- column
   }
 
   si_mat
@@ -583,7 +591,7 @@ build_advantage_si_distr <- function(method, si_distr = NULL, mean_si = NULL,
 #'   is temporarily assigned to `[, , 1]` of the incidence array. We recommend the
 #'   default value of `TRUE` as we find this to stabilise inference.
 #'
-#' @param method one of `"non_parametric_si"` or `"parametric_si"`.
+#' @param method one of `"non_parametric_si"` or `"parametric_si"`. 
 #'
 #' @param mean_si mean serial interval(s) used when `method = "parametric_si"`.
 #'   May be a single value, recycled across all variants, or one value per
@@ -612,7 +620,15 @@ build_advantage_si_distr <- function(method, si_distr = NULL, mean_si = NULL,
 #'   is a named list of the point estimate and upper confidence limits. The
 #'   second element is `NULL` and can be ignored.
 #'
-#' @export
+#' @details
+#' The serial interval can be specified either parametrically or non-parametrically.
+#' - If `method = "non_parametric_si"`, the user specifies the serial interval
+#' distribution for each variant as a matrix where each column corresponds to a
+#' variant and each row corresponds to a day. The first row should be 0 (no
+#' probability mass on day 0) and each column should sum to 1.
+#' - If `method = "parametric_si"`, the user specifies the mean and sd of the
+#' serial interval for each variant. The parameters are used to build a matrix
+#' using the function [discr_si()] which is then used in the estimation.
 #'
 #' @examples
 #' n_v <- 2
@@ -644,7 +660,34 @@ build_advantage_si_distr <- function(method, si_distr = NULL, mean_si = NULL,
 #' abline(h = 1, col = "red")
 #' plot(x$R[30, 3, ], type = "l",
 #'      xlab = "Iteration", ylab = "R time 30 location 3")
-
+#'
+#' ## estimate using a parametric serial interval
+#' x_parametric <- estimate_advantage(
+#'   incid,
+#'   priors = priors,
+#'   method = "parametric_si",
+#'   mean_si = 2.6,
+#'   std_si = 1.5,
+#'   t_min = 2L,
+#'   mcmc_control = list(n_iter = 20L, burnin = 5L, thin = 5L)
+#' )
+#' 
+#' # Plotting to check outputs
+#' par(mfrow = c(2, 2))
+#' plot(x_parametric$epsilon, type = "l",
+#'      xlab = "Iteration", ylab = "epsilon")
+#' # Compare with what we expect with constant incidence in all locations
+#' abline(h = 1, col = "red")
+#' plot(x_parametric$R[10, 1, ], type = "l",
+#'      xlab = "Iteration", ylab = "R time 10 location 1")
+#' abline(h = 1, col = "red")
+#' plot(x_parametric$R[20, 2, ], type = "l",
+#'      xlab = "Iteration", ylab = "R time 20 location 2")
+#' abline(h = 1, col = "red")
+#' plot(x_parametric$R[30, 3, ], type = "l",
+#'      xlab = "Iteration", ylab = "R time 30 location 3")
+#'
+#' @export
 estimate_advantage <- function(incid, si_distr = NULL, priors = default_priors(),
                            mcmc_control = default_mcmc_controls(),
                            t_min = NULL, t_max = nrow(incid),

--- a/R/gibbs_draws.R
+++ b/R/gibbs_draws.R
@@ -627,7 +627,9 @@ build_advantage_si_distr <- function(method, si_distr = NULL, mean_si = NULL,
 #' variant and each row corresponds to a day. The first row should be 0 (no
 #' probability mass on day 0) and each column should sum to 1.
 #' - If `method = "parametric_si"`, the user specifies the mean and sd of the
-#' serial interval for each variant. The parameters are used to build a matrix
+#' serial interval for each variant. If only one value is provided, it is
+#' recycled across all variants. 
+#' The parameters are used to build a matrix
 #' using the function [discr_si()] which is then used in the estimation.
 #'
 #' @examples

--- a/R/gibbs_draws.R
+++ b/R/gibbs_draws.R
@@ -404,13 +404,17 @@ draw_R <- function(epsilon, incid, lambda, priors,
 #' (across all columns) such that the cumulative probability mass before index is
 #' `1 - miss_at_most`.
 #'
-#' @inheritParams estimate_advantage
+#' @param si_distr a matrix of discretised probability distributions
+#' (each column sums to 1). This could be privided by the user if using
+#' non_parametric serial interval distributions, or could be generated internally
+#' by the function [estimate_advantage()] if using parametric serial interval
+#' distribution specification.
+#' 
 #' @param miss_at_most numeric. Probability mass in the tail of the SI distribution
 #' 
 #' @return integer
 #' @author Sangeeta Bhatia
 #' @export
-
 compute_si_cutoff <- function(si_distr, miss_at_most = 0.05) {
   if (any(abs(colSums(si_distr) - 1) > 0.01)) {
     warning("Input SI distributions should sum to 1. Normalising now", call. = FALSE)
@@ -463,7 +467,7 @@ first_nonzero_incid <- function(incid) {
 #'   across all variants computed using [compute_si_cutoff()]
 #'
 #' @inheritParams compute_si_cutoff
-#' @inheritParams estimate_advantage
+#' @inheritParams estimate_advantage incid
 #' 
 #' @return integer
 #' @author Sangeeta Bhatia

--- a/man/EpiEstim-package.Rd
+++ b/man/EpiEstim-package.Rd
@@ -26,6 +26,11 @@ Useful links:
 \author{
 \strong{Maintainer}: Anne Cori \email{a.cori@imperial.ac.uk} (\href{https://orcid.org/0000-0002-8443-9162}{ORCID})
 
+Authors:
+\itemize{
+  \item Anne Cori \email{a.cori@imperial.ac.uk} (\href{https://orcid.org/0000-0002-8443-9162}{ORCID})
+}
+
 Other contributors:
 \itemize{
   \item Simon Cauchemez [contributor]

--- a/man/compute_si_cutoff.Rd
+++ b/man/compute_si_cutoff.Rd
@@ -8,11 +8,11 @@ mass is captured}
 compute_si_cutoff(si_distr, miss_at_most = 0.05)
 }
 \arguments{
-\item{si_distr}{a matrix with two columns, each containing the probability mass
-function for the discrete serial interval for each of the two
-pathogen/strain/variants, starting with the probability mass function
-for day 0 in the first row, which should be 0. Each column in the matrix
-should sum to 1.}
+\item{si_distr}{a matrix of discretised probability distributions
+(each column sums to 1). This could be privided by the user if using
+non_parametric serial interval distributions, or could be generated internally
+by the function \code{\link[=estimate_advantage]{estimate_advantage()}} if using parametric serial interval
+distribution specification.}
 
 \item{miss_at_most}{numeric. Probability mass in the tail of the SI distribution}
 }

--- a/man/compute_t_min.Rd
+++ b/man/compute_t_min.Rd
@@ -11,11 +11,11 @@ compute_t_min(incid, si_distr, miss_at_most)
 for each time step (1st dimension), location (2nd dimension) and
 pathogen/strain/variant (3rd dimension)}
 
-\item{si_distr}{a matrix with two columns, each containing the probability mass
-function for the discrete serial interval for each of the two
-pathogen/strain/variants, starting with the probability mass function
-for day 0 in the first row, which should be 0. Each column in the matrix
-should sum to 1.}
+\item{si_distr}{a matrix of discretised probability distributions
+(each column sums to 1). This could be privided by the user if using
+non_parametric serial interval distributions, or could be generated internally
+by the function \code{\link[=estimate_advantage]{estimate_advantage()}} if using parametric serial interval
+distribution specification.}
 
 \item{miss_at_most}{numeric. Probability mass in the tail of the SI distribution}
 }

--- a/man/default_priors.Rd
+++ b/man/default_priors.Rd
@@ -9,8 +9,8 @@ default_priors()
 \value{
 a list of default parameters for the priors.
 Values can then be manually edited as in the examples below.
-Users could use functions \code{\link[epitrix:gamma_tools]{epitrix::gamma_shapescale2mucv()}} and
-\code{\link[epitrix:gamma_tools]{epitrix::gamma_mucv2shapescale()}} to set the shape and scale corresponding
+Users could use functions \code{\link[epitrix:gamma_shapescale2mucv]{epitrix::gamma_shapescale2mucv()}} and
+\code{\link[epitrix:gamma_mucv2shapescale]{epitrix::gamma_mucv2shapescale()}} to set the shape and scale corresponding
 to the desired prior mean and coefficient of variation.
 }
 \description{

--- a/man/estimate_advantage.Rd
+++ b/man/estimate_advantage.Rd
@@ -112,7 +112,9 @@ distribution for each variant as a matrix where each column corresponds to a
 variant and each row corresponds to a day. The first row should be 0 (no
 probability mass on day 0) and each column should sum to 1.
 \item If \code{method = "parametric_si"}, the user specifies the mean and sd of the
-serial interval for each variant. The parameters are used to build a matrix
+serial interval for each variant. If only one value is provided, it is
+recycled across all variants.
+The parameters are used to build a matrix
 using the function \code{\link[=discr_si]{discr_si()}} which is then used in the estimation.
 }
 }

--- a/man/estimate_advantage.Rd
+++ b/man/estimate_advantage.Rd
@@ -6,7 +6,7 @@
 \usage{
 estimate_advantage(
   incid,
-  si_distr,
+  si_distr = NULL,
   priors = default_priors(),
   mcmc_control = default_mcmc_controls(),
   t_min = NULL,
@@ -14,7 +14,10 @@ estimate_advantage(
   seed = NULL,
   incid_imported = NULL,
   precompute = TRUE,
-  reorder_incid = TRUE
+  reorder_incid = TRUE,
+  method = c("non_parametric_si", "parametric_si"),
+  mean_si = NULL,
+  std_si = NULL
 )
 }
 \arguments{
@@ -22,11 +25,11 @@ estimate_advantage(
 for each time step (1st dimension), location (2nd dimension) and
 pathogen/strain/variant (3rd dimension)}
 
-\item{si_distr}{a matrix with two columns, each containing the probability mass
-function for the discrete serial interval for each of the two
-pathogen/strain/variants, starting with the probability mass function
-for day 0 in the first row, which should be 0. Each column in the matrix
-should sum to 1.}
+\item{si_distr}{a matrix containing the probability mass function for the
+discrete serial interval for each pathogen/strain/variant, starting with
+the probability mass function for day 0 in the first row, which should be
+0. Each column in the matrix should sum to 1. Used when
+\code{method = "non_parametric_si"}.}
 
 \item{priors}{a list of prior parameters (shape and scale of a gamma
 distribution) for epsilon and R; can be obtained from the function
@@ -63,6 +66,16 @@ incidence array can be internally reordered during the estimation of the
 transmission advantage. If \code{TRUE}, the most transmissible pathogen/strain/variant
 is temporarily assigned to \verb{[, , 1]} of the incidence array. We recommend the
 default value of \code{TRUE} as we find this to stabilise inference.}
+
+\item{method}{one of \code{"non_parametric_si"} or \code{"parametric_si"}.}
+
+\item{mean_si}{mean serial interval(s) used when \code{method = "parametric_si"}.
+May be a single value, recycled across all variants, or one value per
+variant.}
+
+\item{std_si}{standard deviation(s) of the serial interval used when
+\code{method = "parametric_si"}. May be a single value, recycled across all
+variants, or one value per variant.}
 }
 \value{
 A list with the following elements:
@@ -90,6 +103,18 @@ second element is \code{NULL} and can be ignored.
 Jointly estimate the instantaneous reproduction number for a reference
 pathogen/strain/variant and the relative transmissibility of a "new"
 pathogen/strain/variant.
+}
+\details{
+The serial interval can be specified either parametrically or non-parametrically.
+\itemize{
+\item If \code{method = "non_parametric_si"}, the user specifies the serial interval
+distribution for each variant as a matrix where each column corresponds to a
+variant and each row corresponds to a day. The first row should be 0 (no
+probability mass on day 0) and each column should sum to 1.
+\item If \code{method = "parametric_si"}, the user specifies the mean and sd of the
+serial interval for each variant. The parameters are used to build a matrix
+using the function \code{\link[=discr_si]{discr_si()}} which is then used in the estimation.
+}
 }
 \examples{
 n_v <- 2
@@ -121,4 +146,31 @@ plot(x$R[20, 2, ], type = "l",
 abline(h = 1, col = "red")
 plot(x$R[30, 3, ], type = "l",
      xlab = "Iteration", ylab = "R time 30 location 3")
+
+## estimate using a parametric serial interval
+x_parametric <- estimate_advantage(
+  incid,
+  priors = priors,
+  method = "parametric_si",
+  mean_si = 2.6,
+  std_si = 1.5,
+  t_min = 2L,
+  mcmc_control = list(n_iter = 20L, burnin = 5L, thin = 5L)
+)
+
+# Plotting to check outputs
+par(mfrow = c(2, 2))
+plot(x_parametric$epsilon, type = "l",
+     xlab = "Iteration", ylab = "epsilon")
+# Compare with what we expect with constant incidence in all locations
+abline(h = 1, col = "red")
+plot(x_parametric$R[10, 1, ], type = "l",
+     xlab = "Iteration", ylab = "R time 10 location 1")
+abline(h = 1, col = "red")
+plot(x_parametric$R[20, 2, ], type = "l",
+     xlab = "Iteration", ylab = "R time 20 location 2")
+abline(h = 1, col = "red")
+plot(x_parametric$R[30, 3, ], type = "l",
+     xlab = "Iteration", ylab = "R time 30 location 3")
+
 }

--- a/tests/testthat/test-samplers.R
+++ b/tests/testthat/test-samplers.R
@@ -856,6 +856,113 @@ test_that("estimate_advantage uses the correct t_min", {
   expect_false(anyNA(x$R[seq(t_min, dim(x$R)[1]), , ]))
 })
 
+test_that("estimate_advantage parametric_si matches an equivalent discrete SI matrix", {
+  n_v <- 2 # 2 variants
+  n_loc <- 2 # 2 locations
+  T <- 40 # 40 time steps
+
+  priors <- default_priors()
+  mcmc_control <- list(n_iter = 100L, burnin = 20L, thin = 5L)
+
+  incid <- array(10, dim = c(T, n_loc, n_v))
+  mean_si <- c(2.6, 3.1)
+  std_si <- c(1.5, 1.2)
+
+  si_parametric <- matrix(NA_real_, nrow = T, ncol = n_v)
+  for (k in seq_len(n_v)) {
+    col <- discr_si(seq(0, T - 1), mean_si[k], std_si[k])
+    si_parametric[, k] <- col / sum(col)
+  }
+
+  parametric_out <- estimate_advantage(
+    incid,
+    priors = priors,
+    mcmc_control = mcmc_control,
+    seed = 1,
+    t_min = 2L,
+    method = "parametric_si",
+    mean_si = mean_si,
+    std_si = std_si
+  )
+
+  discrete_out <- estimate_advantage(
+    incid,
+    si_parametric,
+    priors = priors,
+    mcmc_control = mcmc_control,
+    seed = 1,
+    t_min = 2L
+  )
+
+  expect_equal(parametric_out$epsilon, discrete_out$epsilon)
+  expect_equal(parametric_out$R, discrete_out$R)
+  expect_equal(parametric_out$convergence, discrete_out$convergence)
+  expect_equal(parametric_out$diag, discrete_out$diag)
+  expect_equal(parametric_out$si_distr, discrete_out$si_distr)
+  expect_equal(parametric_out$SI.Moments, discrete_out$SI.Moments)
+})
+
+test_that("estimate_advantage parametric_si validates SI inputs", {
+  incid <- array(10, dim = c(20, 2, 2))
+  priors <- default_priors()
+
+  expect_error(
+    estimate_advantage(incid, priors = priors, method = "parametric_si", std_si = 1.5),
+    "mean_si must be supplied"
+  )
+  expect_error(
+    estimate_advantage(incid, priors = priors, method = "parametric_si", mean_si = 2.6),
+    "std_si must be supplied"
+  )
+  expect_error(
+    estimate_advantage(incid, priors = priors, method = "parametric_si", mean_si = 1, std_si = 1.5),
+    "mean_si"
+  )
+  expect_error(
+    estimate_advantage(incid, priors = priors, method = "parametric_si", mean_si = 2.6, std_si = 0),
+    "std_si"
+  )
+  expect_error(
+    estimate_advantage(
+      incid,
+      priors = priors,
+      method = "parametric_si",
+      mean_si = c(2.6, 3.1, 3.4),
+      std_si = c(1.5, 1.2, 1.1)
+    ),
+    "length 1 or n_v"
+  )
+})
+
+test_that("estimate_advantage parametric_si uses the computed t_min when omitted", {
+  n_v <- 2
+  n_loc <- 2
+  T <- 50
+  incid <- array(10, dim = c(T, n_loc, n_v))
+  mean_si <- 2.6
+  std_si <- 1.5
+
+  si_parametric <- matrix(NA_real_, nrow = T, ncol = n_v)
+  for (k in seq_len(n_v)) {
+    col <- discr_si(seq(0, T - 1), mean_si, std_si)
+    si_parametric[, k] <- col / sum(col)
+  }
+  expected_t_min <- compute_t_min(incid, si_parametric)
+
+  out <- estimate_advantage(
+    incid,
+    priors = default_priors(),
+    mcmc_control = list(n_iter = 15L, burnin = 5L, thin = 5L),
+    seed = 1,
+    method = "parametric_si",
+    mean_si = mean_si,
+    std_si = std_si
+  )
+
+  expect_true(all(is.na(out$R[seq(1, expected_t_min - 1), , seq_len(dim(out$R)[3])])))
+  expect_false(anyNA(out$R[seq(expected_t_min, dim(out$R)[1]), , seq_len(dim(out$R)[3])]))
+})
+
 
 
 test_that("estimate_advantage convergence checks work with >2 variants", {

--- a/vignettes/MV_EpiEstim_vignette.Rmd
+++ b/vignettes/MV_EpiEstim_vignette.Rmd
@@ -51,7 +51,11 @@ knitr::kables(list(kable(df, col.names = c(" ","Region_1","Region_2","Region_3")
 ```
 
 
-The **serial interval distributions** must be supplied as a matrix with the number of columns matching the number of variants being considered. Each column should contain the probability mass function (PMF) for the discrete serial interval of each variant, starting with the PMF for day zero in the first row (which should be 0) and each column should sum to 1, e.g.:
+The **serial interval distributions** may be supplied
+(1) non-parametrically, as a matrix with the number of columns matching the number of variants being considered, or
+(2) parametrically, by providing the mean and standard deviation for each variant.
+
+In the non-parametric case, each column should contain the probability mass function (PMF) for the discrete serial interval of each variant, starting with the PMF for day zero in the first row (which should be 0) and each column should sum to 1, e.g.:
 
 ```{r, echo=FALSE}
 t <- c("[1,]","[2,]","[3,]","[4,]","...")
@@ -63,12 +67,15 @@ df <- data.frame(t,Variant_1,Variant_2)
 knitr::kable(df, col.names = c(" ","Variant_1","Variant_2"))
 ```
 
+In the parametric case, EpiEstim will build the serial interval matrix using the function `discr_si`, which assumes that the serial interval is a shifted Gamma distribution with shift 1.
 
-##Estimate advantage
+
+
+## Estimate advantage
 
 To estimate the effective transmission advantage of new variants compared to a reference variant we use the `estimate_advantage()` function in `EpiEstim`.
 
-###`estimate_advantage()`
+### `estimate_advantage()`
 
 ```{r, eval=FALSE}
 estimate_advantage(incid = incidence_object, 
@@ -120,13 +127,11 @@ Let us say we have incidence data in the format below, where each row correspond
 head(incid)
 ```
 
-We also assume that the SI is the same for both variants, with a mean of 5.4 days and a standard deviation of 1.5 days (Rai, Shukla, and Dwivedi 2021) and produce a matrix of SI's with the number of columns equal to the number of variants:
+We also assume that the SI is the same for both variants, with a mean of 5.4 days and a standard deviation of 1.5 days (Rai, Shukla, and Dwivedi 2021) and use `parametric_si` to input these.
 
 ```{r}
 mean_SI <- 5.4
 sd_SI <- 1.5
-SI <- EpiEstim::discr_si(seq(0, 20), mean_SI, sd_SI)
-si_matrix <- cbind(SI,SI)
 ```
 
 ```{r}
@@ -139,9 +144,12 @@ Now that we have our incidence and SI distributions we can supply these to the `
 
 ```{r, message=FALSE, warning=FALSE}
 output <- EpiEstim::estimate_advantage(incid = incid,
-                             si_distr = si_matrix,
+                             si_distr = NULL,
                              priors = default_priors(),
-                             mcmc_control = default_mcmc_controls())
+                             mcmc_control = default_mcmc_controls(),
+                             method = "parametric_si",
+                             mean_si = mean_SI,
+                             std_si = sd_SI)
 ```
 
 The output is a list containing 4 elements:

--- a/vignettes/MV_EpiEstim_vignette.Rmd
+++ b/vignettes/MV_EpiEstim_vignette.Rmd
@@ -134,10 +134,6 @@ mean_SI <- 5.4
 sd_SI <- 1.5
 ```
 
-```{r}
-head(si_matrix)
-```
-
 **Estimate transmission advantage**
 
 Now that we have our incidence and SI distributions we can supply these to the `estimate_advantage()` function. We use the default priors and MCMC controls.


### PR DESCRIPTION
This pull request adds support for parametric serial interval specification to the `estimate_advantage` function, allowing users to specify the serial interval using mean and standard deviation parameters instead of only providing a non-parametric distribution. It also updates the documentation and examples to reflect this new feature and clarifies parameter requirements and behavior throughout the codebase.

**New Feature: Parametric Serial Interval Support**
- `estimate_advantage` now accepts a `method` argument to choose between `"non_parametric_si"` and `"parametric_si"`, and supports `mean_si` and `std_si` parameters for parametric specification. Internally, a helper function `build_advantage_si_distr` was added to construct the appropriate serial interval matrix based on the chosen method. [[1]](diffhunk://#diff-c7f24eeae09ccfe4e0e5e4341ea2bcf4a02b63c89c0367c35d361fe9d5d661cdL467-R545) [[2]](diffhunk://#diff-c7f24eeae09ccfe4e0e5e4341ea2bcf4a02b63c89c0367c35d361fe9d5d661cdL583-R719)

**Documentation Updates**
- The function documentation for `estimate_advantage`, `compute_si_cutoff`, and `compute_t_min` has been expanded and clarified to describe the new parametric serial interval option, including usage details, parameter descriptions, and examples. [[1]](diffhunk://#diff-3e04eead0b2641ccd367ff9c0880f018268499525210e2e8ef6a43291bd46d05L9-R32) [[2]](diffhunk://#diff-3e04eead0b2641ccd367ff9c0880f018268499525210e2e8ef6a43291bd46d05R69-R78) [[3]](diffhunk://#diff-3e04eead0b2641ccd367ff9c0880f018268499525210e2e8ef6a43291bd46d05R107-R118) [[4]](diffhunk://#diff-3e04eead0b2641ccd367ff9c0880f018268499525210e2e8ef6a43291bd46d05R149-R175) [[5]](diffhunk://#diff-0fc03cea2649d90f39bc5f124cb113c9fcf6bcf24fff10354037837effcde6e8L11-R15) [[6]](diffhunk://#diff-9e326b1a8f0ea5576ba9e78a033c71e1e9d293386d591170cecb5fd28bddade1L14-R18)
-  MV-EpiEstim vignette has been updated.
- The `NEWS.md` file announces the new feature for users.


**Maintenance**
- Updated package version to 3.0.1 and adjusted Roxygen and configuration metadata. [[1]](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL2-R2) [[2]](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL61-R63)

No breaking changes were introduced; existing workflows using non-parametric serial intervals will continue to work as before.