### PR TITLE
Resolve pkgdown warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,8 @@ Description: Tools to quantify transmissibility throughout
     an epidemic from the analysis of time series of incidence as described in
     Cori et al. (2013) <doi:10.1093/aje/kwt133> and Wallinga and Teunis (2004) 
     <doi:10.1093/aje/kwh255>.
-URL: https://github.com/mrc-ide/EpiEstim
+URL: https://mrc-ide.github.io/EpiEstim,
+    https://github.com/mrc-ide/EpiEstim
 BugReports: https://github.com/mrc-ide/EpiEstim/issues
 Depends: R (>= 3.3.0)
 Imports:
@@ -58,6 +59,6 @@ License: GPL (>=2)
 LazyLoad: yes
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3
 VignetteBuilder: knitr
 Remotes: reconverse/incidence2/pkg
+Config/roxygen2/version: 8.0.0

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,6 @@
 url: https://mrc-ide.github.io/EpiEstim
 template:
-  bootstrap: 3
+  bootstrap: 5
 
 reference:
   - title: Pre-processing

--- a/vignettes/MV_EpiEstim_vignette.Rmd
+++ b/vignettes/MV_EpiEstim_vignette.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "MV-EpiEstim"
+title: "Multivariant EpiEstim"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
 vignette: >

--- a/vignettes/full_EpiEstim_vignette.Rmd
+++ b/vignettes/full_EpiEstim_vignette.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "EpiEstim Vignette"
+title: "Full EpiEstim vignette"
 author: "Rebecca Nash"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette

--- a/vignettes/short_demo.Rmd
+++ b/vignettes/short_demo.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "EpiEstim: a demonstration"
+title: "EpiEstim demonstration"
 author: "Anne Cori"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette


### PR DESCRIPTION
- Updated _pkgdown.yml to use Bootstrap 5
- Updated DESCRIPTION to include website URL
- Updated vignette titles to be consistent with the index entry

These changes fixed most of the warnings. Locally updating rmarkdown to 2.31 resolved the ones about deprecated syntax.
